### PR TITLE
Fix: Search fails silently due to $orderby/$filter conflict with $search

### DIFF
--- a/email/search.js
+++ b/email/search.js
@@ -98,23 +98,28 @@ async function progressiveSearch(endpoint, accessToken, searchTerms, filterTerms
         searchAttempts.push(`single-term-${term}`);
         
         // For single term search, only use $search with that term
+        // Graph API does not support $orderby or $filter with $search
         const simplifiedParams = {
           $top: Math.min(50, maxCount),
-          $select: config.EMAIL_SELECT_FIELDS,
-          $orderby: 'receivedDateTime desc'
+          $select: config.EMAIL_SELECT_FIELDS
         };
+        
+        // Build KQL terms for search
+        const kqlParts = [];
         
         // Add the search term in the appropriate KQL syntax
         if (term === 'query') {
           // General query doesn't need a prefix
-          simplifiedParams.$search = `"${searchTerms[term]}"`;
+          kqlParts.push(searchTerms[term]);
         } else {
           // Specific field searches use field:value syntax
-          simplifiedParams.$search = `${term}:"${searchTerms[term]}"`;
+          kqlParts.push(`${term}:${searchTerms[term]}`);
         }
         
-        // Add boolean filters if applicable
-        addBooleanFilters(simplifiedParams, filterTerms);
+        // Add boolean filters as KQL (can't use $filter with $search)
+        addBooleanFiltersAsKQL(kqlParts, filterTerms);
+        
+        simplifiedParams.$search = `"${kqlParts.join(' ')}"`;
         
         const response = await callGraphAPIPaginated(accessToken, 'GET', endpoint, simplifiedParams, maxCount);
         if (response.value && response.value.length > 0) {
@@ -184,8 +189,7 @@ async function progressiveSearch(endpoint, accessToken, searchTerms, filterTerms
 function buildSearchParams(searchTerms, filterTerms, count) {
   const params = {
     $top: count,
-    $select: config.EMAIL_SELECT_FIELDS,
-    $orderby: 'receivedDateTime desc'
+    $select: config.EMAIL_SELECT_FIELDS
   };
   
   // Handle search terms
@@ -210,17 +214,22 @@ function buildSearchParams(searchTerms, filterTerms, count) {
   
   // Add $search if we have any search terms
   if (kqlTerms.length > 0) {
-    params.$search = kqlTerms.join(' ');
+    // Graph API does not support $orderby or $filter with $search
+    // Move boolean filters into KQL syntax instead
+    addBooleanFiltersAsKQL(kqlTerms, filterTerms);
+    params.$search = `"${kqlTerms.join(' ')}"`;
+  } else {
+    // No search terms — safe to use $orderby and $filter
+    params.$orderby = 'receivedDateTime desc';
+    addBooleanFilters(params, filterTerms);
   }
-  
-  // Add boolean filters
-  addBooleanFilters(params, filterTerms);
   
   return params;
 }
 
 /**
- * Add boolean filters to query parameters
+ * Add boolean filters to query parameters as OData $filter
+ * Only use when $search is NOT present (they conflict in Graph API)
  * @param {object} params - Query parameters
  * @param {object} filterTerms - Filter terms (hasAttachments, unreadOnly)
  */
@@ -238,6 +247,22 @@ function addBooleanFilters(params, filterTerms) {
   // Add $filter parameter if we have any filter conditions
   if (filterConditions.length > 0) {
     params.$filter = filterConditions.join(' and ');
+  }
+}
+
+/**
+ * Add boolean filters as KQL terms for use with $search
+ * Use this instead of addBooleanFilters when $search is present
+ * @param {string[]} kqlTerms - Array of KQL terms to append to
+ * @param {object} filterTerms - Filter terms (hasAttachments, unreadOnly)
+ */
+function addBooleanFiltersAsKQL(kqlTerms, filterTerms) {
+  if (filterTerms.hasAttachments === true) {
+    kqlTerms.push('hasAttachments:true');
+  }
+  
+  if (filterTerms.unreadOnly === true) {
+    kqlTerms.push('isRead:false');
   }
 }
 


### PR DESCRIPTION
## **User description**
## Problem

Email search was silently failing and returning recent emails instead of actual search results. Searching by `from`, `subject`, `query`, etc. never matched anything.

## Root Cause

The Microsoft Graph API **does not allow `$orderby` or `$filter` to be combined with `$search`**. Every search strategy in `email/search.js` was including `$orderby: 'receivedDateTime desc'` alongside `$search`, causing the API to return a 400 error. The error was silently caught, and the code fell through all strategies until the final fallback — which just returned recent emails.

## Fix

- **Removed `$orderby`** from query params when `$search` is present (search results come back in relevance order from the Graph search index)
- **Moved boolean filters** (`hasAttachments`, `unreadOnly`) into KQL syntax when used with `$search`, since `$filter` also conflicts. For example, `hasAttachments eq true` becomes `hasAttachments:true` inside the KQL query string
- **Kept `$orderby` and `$filter`** for non-search queries (e.g., boolean-only filters, recent emails fallback)

## Testing

Search with `from`, `subject`, `query`, `hasAttachments`, and `unreadOnly` parameters should now return actual matching results instead of falling through to the recent-emails fallback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved search query construction for better consistency and API compliance. Search filtering now uses an optimized query approach to enhance performance and reliability with various filter combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Fix search returning recent emails instead of actual matches

### What Changed
- Searches with free-text or fielded terms (from, subject, to, query) now return matching emails instead of silently falling back to recent emails
- Boolean filters (hasAttachments, unreadOnly) are applied when using search by converting them into search-query syntax so they filter results correctly
- Non-search requests (no free-text/field terms) continue to return recent emails and support explicit ordering and OData filters

### Impact
`✅ Actual search results returned for user queries`
`✅ Search respects attachment and unread filters`
`✅ Recent-emails behavior unchanged for non-search requests`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
