### PR TITLE
fix: token refresh env vars, delete-email tool, npx support

### DIFF
--- a/auth/token-storage.js
+++ b/auth/token-storage.js
@@ -8,10 +8,14 @@ class TokenStorage {
     const tenantId = process.env.MS_TENANT_ID || 'common';
     const authorityHost = (process.env.MS_AUTHORITY_HOST || 'https://login.microsoftonline.com').replace(/\/+$/, '');
 
+    // Support both MS_CLIENT_ID (auth server / .env) and OUTLOOK_CLIENT_ID (Claude Desktop config)
+    const clientId = process.env.MS_CLIENT_ID || process.env.OUTLOOK_CLIENT_ID;
+    const clientSecret = process.env.MS_CLIENT_SECRET || process.env.OUTLOOK_CLIENT_SECRET;
+
     this.config = {
       tokenStorePath: path.join(process.env.HOME || process.env.USERPROFILE, '.outlook-mcp-tokens.json'),
-      clientId: process.env.MS_CLIENT_ID,
-      clientSecret: process.env.MS_CLIENT_SECRET,
+      clientId,
+      clientSecret,
       redirectUri: process.env.MS_REDIRECT_URI || 'http://localhost:3333/auth/callback',
       scopes: (process.env.MS_SCOPES || 'offline_access User.Read Mail.Read').split(' '),
       tenantId,
@@ -24,7 +28,7 @@ class TokenStorage {
     this._refreshPromise = null;
 
     if (!this.config.clientId || !this.config.clientSecret) {
-      console.warn("TokenStorage: MS_CLIENT_ID or MS_CLIENT_SECRET is not configured. Token operations might fail.");
+      console.warn("TokenStorage: Client ID or Secret is not configured (checked MS_CLIENT_ID/OUTLOOK_CLIENT_ID). Token refresh will fail.");
     }
   }
 

--- a/email/delete.js
+++ b/email/delete.js
@@ -1,0 +1,52 @@
+/**
+ * Delete email functionality (move to Deleted Items / trash)
+ */
+const { callGraphAPI } = require('../utils/graph-api');
+const { ensureAuthenticated } = require('../auth');
+
+/**
+ * Delete email handler - moves email to Deleted Items folder
+ * @param {object} args - Tool arguments
+ * @returns {object} - MCP response
+ */
+async function handleDeleteEmail(args) {
+  const emailId = args.id;
+  const permanent = args.permanent === true;
+
+  if (!emailId) {
+    return {
+      content: [{ type: "text", text: "Email ID is required." }]
+    };
+  }
+
+  try {
+    const accessToken = await ensureAuthenticated();
+
+    if (permanent) {
+      // Hard delete - permanently remove the message
+      await callGraphAPI(accessToken, 'DELETE', `me/messages/${encodeURIComponent(emailId)}`);
+      return {
+        content: [{ type: "text", text: "Email permanently deleted." }]
+      };
+    } else {
+      // Soft delete - move to Deleted Items (trash)
+      const result = await callGraphAPI(accessToken, 'POST', `me/messages/${encodeURIComponent(emailId)}/move`, {
+        destinationId: 'deleteditems'
+      });
+      return {
+        content: [{ type: "text", text: `Email moved to Deleted Items. ID: ${result.id}` }]
+      };
+    }
+  } catch (error) {
+    if (error.message === 'Authentication required') {
+      return {
+        content: [{ type: "text", text: "Authentication required. Please use the 'authenticate' tool first." }]
+      };
+    }
+    return {
+      content: [{ type: "text", text: `Failed to delete email: ${error.message}` }]
+    };
+  }
+}
+
+module.exports = handleDeleteEmail;

--- a/email/delete.js
+++ b/email/delete.js
@@ -9,7 +9,7 @@ const { ensureAuthenticated } = require('../auth');
  * @param {object} args - Tool arguments
  * @returns {object} - MCP response
  */
-async function handleDeleteEmail(args) {
+async function handleDeleteEmail(args = {}) {
   const emailId = args.id;
   const permanent = args.permanent === true;
 
@@ -23,8 +23,8 @@ async function handleDeleteEmail(args) {
     const accessToken = await ensureAuthenticated();
 
     if (permanent) {
-      // Hard delete - permanently remove the message
-      await callGraphAPI(accessToken, 'DELETE', `me/messages/${encodeURIComponent(emailId)}`);
+      // Hard delete - permanently remove the message via permanentDelete endpoint
+      await callGraphAPI(accessToken, 'POST', `me/messages/${encodeURIComponent(emailId)}/permanentDelete`);
       return {
         content: [{ type: "text", text: "Email permanently deleted." }]
       };
@@ -38,7 +38,7 @@ async function handleDeleteEmail(args) {
       };
     }
   } catch (error) {
-    if (error.message === 'Authentication required') {
+    if (error.message === 'Authentication required' || error.message === 'UNAUTHORIZED') {
       return {
         content: [{ type: "text", text: "Authentication required. Please use the 'authenticate' tool first." }]
       };

--- a/email/index.js
+++ b/email/index.js
@@ -7,6 +7,7 @@ const handleReadEmail = require('./read');
 const handleSendEmail = require('./send');
 const handleDraftEmail = require('./draft');
 const handleMarkAsRead = require('./mark-as-read');
+const handleDeleteEmail = require('./delete');
 
 // Email tool definitions
 const emailTools = [
@@ -189,6 +190,25 @@ const emailTools = [
       required: ["id"]
     },
     handler: handleMarkAsRead
+  },
+  {
+    name: "delete-email",
+    description: "Deletes an email by moving it to Deleted Items (trash). Use permanent=true to hard delete.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        id: {
+          type: "string",
+          description: "ID of the email to delete"
+        },
+        permanent: {
+          type: "boolean",
+          description: "If true, permanently delete the email instead of moving to Deleted Items. Default: false"
+        }
+      },
+      required: ["id"]
+    },
+    handler: handleDeleteEmail
   }
 ];
 
@@ -199,5 +219,6 @@ module.exports = {
   handleReadEmail,
   handleSendEmail,
   handleDraftEmail,
-  handleMarkAsRead
+  handleMarkAsRead,
+  handleDeleteEmail
 };

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "2.0.0",
   "description": "MCP server for Claude to access Microsoft 365 (Outlook, OneDrive, Power Automate) via Microsoft Graph API",
   "main": "index.js",
+  "bin": {
+    "m365-mcp": "./index.js",
+    "m365-mcp-auth": "./outlook-auth-server.js"
+  },
   "scripts": {
     "start": "node index.js",
     "auth-server": "node outlook-auth-server.js",


### PR DESCRIPTION
## Summary
- **Fix silent token refresh failure in Claude Desktop** (closes #44): `TokenStorage` only read `MS_CLIENT_ID`/`MS_CLIENT_SECRET`, but Claude Desktop injects `OUTLOOK_CLIENT_ID`/`OUTLOOK_CLIENT_SECRET`. Refresh token grant was silently failing, forcing re-authentication on every token expiry. Now checks both env var names with fallback.
- **Add `delete-email` tool** (closes #27): Moves email to Deleted Items by default. Supports `permanent: true` for hard delete.
- **Add `bin` to package.json** (partial #36): Enables `npx m365-mcp` and `npx m365-mcp-auth` without cloning.

## Root Cause (Issue #44)
```
# Claude Desktop config sets:
OUTLOOK_CLIENT_ID=xxx
OUTLOOK_CLIENT_SECRET=yyy

# But TokenStorage only checked:
process.env.MS_CLIENT_ID   → undefined
process.env.MS_CLIENT_SECRET → undefined

# Result: refresh_token grant had no credentials → failed → user forced to re-auth
```

## Test plan
- [ ] Verify Claude Desktop can refresh tokens without re-authenticating (set only `OUTLOOK_CLIENT_ID` in MCP config, let access token expire)
- [ ] Test `delete-email` moves message to Deleted Items
- [ ] Test `delete-email` with `permanent: true` removes message entirely
- [ ] Verify `npx m365-mcp` works after `npm install -g`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Email deletion: delete messages permanently or move them to Deleted Items.
  * CLI entry points: two command-line executables added for streamlined access.

* **Improvements**
  * OAuth credential handling now accepts multiple environment variable sources for client ID/secret, with clearer startup warnings when credentials are missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->