### PR TITLE
fix: recursive folder lookup for nested mail folders

### DIFF
--- a/email/folder-utils.js
+++ b/email/folder-utils.js
@@ -144,7 +144,7 @@ async function getAllFolders(accessToken) {
     return await fetchFoldersRecursive(accessToken, 'me/mailFolders', selectFields);
   } catch (error) {
     console.error(`Error getting all folders: ${error.message}`);
-    return [];
+    throw error;
   }
 }
 
@@ -156,19 +156,41 @@ async function getAllFolders(accessToken) {
  * @returns {Promise<Array>} - Flat array of all folder objects
  */
 async function fetchFoldersRecursive(accessToken, endpoint, selectFields) {
-  const response = await callGraphAPI(
-    accessToken,
-    'GET',
-    endpoint,
-    null,
-    { $top: 100, $select: selectFields }
-  );
+  // Paginate through all results rather than capping at 100
+  let folders = [];
+  let nextEndpoint = endpoint;
+  let nextParams = { $top: 100, $select: selectFields };
 
-  if (!response.value || response.value.length === 0) {
+  while (nextEndpoint) {
+    const response = await callGraphAPI(
+      accessToken,
+      'GET',
+      nextEndpoint,
+      null,
+      nextParams
+    );
+
+    if (!response.value || response.value.length === 0) {
+      break;
+    }
+
+    folders = folders.concat(response.value);
+
+    // Graph API returns a full URL in @odata.nextLink; extract the relative path
+    if (response['@odata.nextLink']) {
+      const nextUrl = new URL(response['@odata.nextLink']);
+      // Use the path after "/v1.0/" as the next endpoint, params are embedded in nextLink
+      nextEndpoint = nextUrl.pathname.replace(/^\/v1\.0\//, '');
+      nextParams = Object.fromEntries(nextUrl.searchParams.entries());
+    } else {
+      nextEndpoint = null;
+    }
+  }
+
+  if (folders.length === 0) {
     return [];
   }
 
-  const folders = response.value;
   const withChildren = folders.filter(f => f.childFolderCount > 0);
 
   const childResults = await Promise.all(withChildren.map(async (folder) => {
@@ -180,7 +202,7 @@ async function fetchFoldersRecursive(accessToken, endpoint, selectFields) {
       );
     } catch (error) {
       console.error(`Error getting child folders for "${folder.displayName}": ${error.message}`);
-      return [];
+      throw error;
     }
   }));
 

--- a/email/folder-utils.js
+++ b/email/folder-utils.js
@@ -66,8 +66,32 @@ async function resolveFolderPath(accessToken, folderName) {
  * @returns {Promise<string|null>} - Folder ID or null if not found
  */
 async function getFolderIdByName(accessToken, folderName) {
+  // Map well-known folder names to their Graph API aliases
+  const WELL_KNOWN_FOLDER_IDS = {
+    'deleted items': 'deleteditems',
+    'deleted': 'deleteditems',
+    'sent items': 'sentitems',
+    'sent': 'sentitems',
+    'drafts': 'drafts',
+    'inbox': 'inbox',
+    'junk email': 'junkemail',
+    'junk': 'junkemail',
+    'archive': 'archive'
+  };
+
   try {
-    // First try with exact match filter
+    // Check well-known folders first — these have fixed IDs in Graph API
+    const wellKnownId = WELL_KNOWN_FOLDER_IDS[folderName.toLowerCase()];
+    if (wellKnownId) {
+      console.error(`Using well-known folder ID "${wellKnownId}" for "${folderName}"`);
+      const wkResponse = await callGraphAPI(accessToken, 'GET', `me/mailFolders/${wellKnownId}`);
+      if (wkResponse && wkResponse.id) {
+        console.error(`Resolved well-known folder "${folderName}" to ID: ${wkResponse.id}`);
+        return wkResponse.id;
+      }
+    }
+
+    // Try exact match filter
     console.error(`Looking for folder with name "${folderName}"`);
     const response = await callGraphAPI(
       accessToken,
@@ -82,24 +106,18 @@ async function getFolderIdByName(accessToken, folderName) {
       return response.value[0].id;
     }
     
-    // If exact match fails, try to get all folders and do a case-insensitive comparison
-    console.error(`No exact match found for "${folderName}", trying case-insensitive search`);
-    const allFoldersResponse = await callGraphAPI(
-      accessToken,
-      'GET',
-      'me/mailFolders',
-      null,
-      { $top: 100 }
-    );
-    
-    if (allFoldersResponse.value) {
+    // If exact match fails, try all folders (including child folders) with case-insensitive comparison
+    console.error(`No exact match found for "${folderName}", trying full folder search`);
+    const allFolders = await getAllFolders(accessToken);
+
+    if (allFolders.length > 0) {
       const lowerFolderName = folderName.toLowerCase();
-      const matchingFolder = allFoldersResponse.value.find(
+      const matchingFolder = allFolders.find(
         folder => folder.displayName.toLowerCase() === lowerFolderName
       );
-      
+
       if (matchingFolder) {
-        console.error(`Found case-insensitive match for "${folderName}" with ID: ${matchingFolder.id}`);
+        console.error(`Found match for "${folderName}" with ID: ${matchingFolder.id}`);
         return matchingFolder.id;
       }
     }
@@ -118,53 +136,52 @@ async function getFolderIdByName(accessToken, folderName) {
  * @returns {Promise<Array>} - Array of folder objects
  */
 async function getAllFolders(accessToken) {
+  const selectFields = 'id,displayName,parentFolderId,childFolderCount,totalItemCount,unreadItemCount';
   try {
-    // Get top-level folders
-    const response = await callGraphAPI(
-      accessToken,
-      'GET',
-      'me/mailFolders',
-      null,
-      { 
-        $top: 100,
-        $select: 'id,displayName,parentFolderId,childFolderCount,totalItemCount,unreadItemCount'
-      }
-    );
-    
-    if (!response.value) {
-      return [];
-    }
-    
-    // Get child folders for folders with children
-    const foldersWithChildren = response.value.filter(f => f.childFolderCount > 0);
-    
-    const childFolderPromises = foldersWithChildren.map(async (folder) => {
-      try {
-        const childResponse = await callGraphAPI(
-          accessToken,
-          'GET',
-          `me/mailFolders/${folder.id}/childFolders`,
-          null,
-          { 
-            $select: 'id,displayName,parentFolderId,childFolderCount,totalItemCount,unreadItemCount'
-          }
-        );
-        
-        return childResponse.value || [];
-      } catch (error) {
-        console.error(`Error getting child folders for "${folder.displayName}": ${error.message}`);
-        return [];
-      }
-    });
-    
-    const childFolders = await Promise.all(childFolderPromises);
-    
-    // Combine top-level folders and all child folders
-    return [...response.value, ...childFolders.flat()];
+    return await fetchFoldersRecursive(accessToken, 'me/mailFolders', selectFields);
   } catch (error) {
     console.error(`Error getting all folders: ${error.message}`);
     return [];
   }
+}
+
+/**
+ * Recursively fetch folders and all their descendants
+ * @param {string} accessToken - Access token
+ * @param {string} endpoint - Graph API endpoint to fetch folders from
+ * @param {string} selectFields - Fields to select
+ * @returns {Promise<Array>} - Flat array of all folder objects
+ */
+async function fetchFoldersRecursive(accessToken, endpoint, selectFields) {
+  const response = await callGraphAPI(
+    accessToken,
+    'GET',
+    endpoint,
+    null,
+    { $top: 100, $select: selectFields }
+  );
+
+  if (!response.value || response.value.length === 0) {
+    return [];
+  }
+
+  const folders = response.value;
+  const withChildren = folders.filter(f => f.childFolderCount > 0);
+
+  const childResults = await Promise.all(withChildren.map(async (folder) => {
+    try {
+      return await fetchFoldersRecursive(
+        accessToken,
+        `me/mailFolders/${folder.id}/childFolders`,
+        selectFields
+      );
+    } catch (error) {
+      console.error(`Error getting child folders for "${folder.displayName}": ${error.message}`);
+      return [];
+    }
+  }));
+
+  return [...folders, ...childResults.flat()];
 }
 
 module.exports = {

--- a/email/folder-utils.js
+++ b/email/folder-utils.js
@@ -112,13 +112,16 @@ async function getFolderIdByName(accessToken, folderName) {
 
     if (allFolders.length > 0) {
       const lowerFolderName = folderName.toLowerCase();
-      const matchingFolder = allFolders.find(
+      const matches = allFolders.filter(
         folder => folder.displayName.toLowerCase() === lowerFolderName
       );
 
-      if (matchingFolder) {
-        console.error(`Found match for "${folderName}" with ID: ${matchingFolder.id}`);
-        return matchingFolder.id;
+      if (matches.length === 1) {
+        console.error(`Found match for "${folderName}" with ID: ${matches[0].id}`);
+        return matches[0].id;
+      } else if (matches.length > 1) {
+        console.error(`Ambiguous folder name "${folderName}" — ${matches.length} folders match: ${matches.map(f => f.id).join(', ')}`);
+        return null;
       }
     }
     
@@ -188,5 +191,6 @@ module.exports = {
   WELL_KNOWN_FOLDERS,
   resolveFolderPath,
   getFolderIdByName,
-  getAllFolders
+  getAllFolders,
+  fetchFoldersRecursive
 };

--- a/folder/list.js
+++ b/folder/list.js
@@ -64,68 +64,65 @@ async function handleListFolders(args) {
  */
 async function getAllFoldersHierarchy(accessToken, includeItemCounts) {
   try {
-    // Determine select fields based on whether to include counts
     const selectFields = includeItemCounts
       ? 'id,displayName,parentFolderId,childFolderCount,totalItemCount,unreadItemCount'
       : 'id,displayName,parentFolderId,childFolderCount';
-    
-    // Get all mail folders
+
+    const allFolders = await fetchFoldersRecursive(accessToken, 'me/mailFolders', selectFields);
+
+    // Mark top-level folders (those fetched from the root endpoint)
     const response = await callGraphAPI(
       accessToken,
       'GET',
       'me/mailFolders',
       null,
-      { 
-        $top: 100,
-        $select: selectFields
-      }
+      { $top: 100, $select: 'id' }
     );
-    
-    if (!response.value) {
-      return [];
-    }
-    
-    // Get child folders for folders with children
-    const foldersWithChildren = response.value.filter(f => f.childFolderCount > 0);
-    
-    const childFolderPromises = foldersWithChildren.map(async (folder) => {
-      try {
-        const childResponse = await callGraphAPI(
-          accessToken,
-          'GET',
-          `me/mailFolders/${folder.id}/childFolders`,
-          null,
-          { $select: selectFields }
-        );
-        
-        // Add parent folder info to each child
-        const childFolders = childResponse.value || [];
-        childFolders.forEach(child => {
-          child.parentFolder = folder.displayName;
-        });
-        
-        return childFolders;
-      } catch (error) {
-        console.error(`Error getting child folders for "${folder.displayName}": ${error.message}`);
-        return [];
-      }
-    });
-    
-    const childFolders = await Promise.all(childFolderPromises);
-    const allChildFolders = childFolders.flat();
-    
-    // Add top-level flag to parent folders
-    const topLevelFolders = response.value.map(folder => ({
+    const topLevelIds = new Set((response.value || []).map(f => f.id));
+
+    return allFolders.map(folder => ({
       ...folder,
-      isTopLevel: true
+      isTopLevel: topLevelIds.has(folder.id)
     }));
-    
-    // Combine all folders
-    return [...topLevelFolders, ...allChildFolders];
   } catch (error) {
     console.error(`Error getting all folders: ${error.message}`);
     throw error;
   }
+}
+
+/**
+ * Recursively fetch folders and all their descendants
+ */
+async function fetchFoldersRecursive(accessToken, endpoint, selectFields) {
+  const response = await callGraphAPI(
+    accessToken,
+    'GET',
+    endpoint,
+    null,
+    { $top: 100, $select: selectFields }
+  );
+
+  if (!response.value || response.value.length === 0) {
+    return [];
+  }
+
+  const folders = response.value;
+  const withChildren = folders.filter(f => f.childFolderCount > 0);
+
+  const childResults = await Promise.all(withChildren.map(async (folder) => {
+    try {
+      return await fetchFoldersRecursive(
+        accessToken,
+        `me/mailFolders/${folder.id}/childFolders`,
+        selectFields
+      );
+    } catch (error) {
+      console.error(`Error getting child folders for "${folder.displayName}": ${error.message}`);
+      return [];
+    }
+  }));
+
+  return [...folders, ...childResults.flat()];
 }
 
 /**

--- a/folder/list.js
+++ b/folder/list.js
@@ -3,6 +3,7 @@
  */
 const { callGraphAPI } = require('../utils/graph-api');
 const { ensureAuthenticated } = require('../auth');
+const { fetchFoldersRecursive } = require('../email/folder-utils');
 
 /**
  * List folders handler
@@ -70,59 +71,20 @@ async function getAllFoldersHierarchy(accessToken, includeItemCounts) {
 
     const allFolders = await fetchFoldersRecursive(accessToken, 'me/mailFolders', selectFields);
 
-    // Mark top-level folders (those fetched from the root endpoint)
-    const response = await callGraphAPI(
-      accessToken,
-      'GET',
-      'me/mailFolders',
-      null,
-      { $top: 100, $select: 'id' }
-    );
-    const topLevelIds = new Set((response.value || []).map(f => f.id));
+    // Derive isTopLevel and parentFolder from the data itself —
+    // a folder is top-level if its parentFolderId isn't any folder we fetched
+    const allIds = new Set(allFolders.map(f => f.id));
+    const nameById = new Map(allFolders.map(f => [f.id, f.displayName]));
 
     return allFolders.map(folder => ({
       ...folder,
-      isTopLevel: topLevelIds.has(folder.id)
+      isTopLevel: !allIds.has(folder.parentFolderId),
+      parentFolder: nameById.get(folder.parentFolderId) || null
     }));
   } catch (error) {
     console.error(`Error getting all folders: ${error.message}`);
     throw error;
   }
-}
-
-/**
- * Recursively fetch folders and all their descendants
- */
-async function fetchFoldersRecursive(accessToken, endpoint, selectFields) {
-  const response = await callGraphAPI(
-    accessToken,
-    'GET',
-    endpoint,
-    null,
-    { $top: 100, $select: selectFields }
-  );
-
-  if (!response.value || response.value.length === 0) {
-    return [];
-  }
-
-  const folders = response.value;
-  const withChildren = folders.filter(f => f.childFolderCount > 0);
-
-  const childResults = await Promise.all(withChildren.map(async (folder) => {
-    try {
-      return await fetchFoldersRecursive(
-        accessToken,
-        `me/mailFolders/${folder.id}/childFolders`,
-        selectFields
-      );
-    } catch (error) {
-      console.error(`Error getting child folders for "${folder.displayName}": ${error.message}`);
-      return [];
-    }
-  }));
-
-  return [...folders, ...childResults.flat()];
 }
 
 /**


### PR DESCRIPTION
## Summary
- `getAllFolders` (email/folder-utils.js) and `getAllFoldersHierarchy` (folder/list.js) only fetched one level of child folders from the Graph API
- Folders nested 2+ levels deep (e.g., Inbox > Shopping > Orders > Walmart) were invisible to list-folders, move-emails, and create-rule operations
- Extracted a recursive `fetchFoldersRecursive` helper that walks the full folder tree via `mailFolders/{id}/childFolders` endpoints

## Test plan
- [x] All 131 existing tests pass
- [x] Verified live: `list-folders --includeChildren` now shows 3+ level nesting
- [x] Verified live: `move-emails` and `create-rule` can target deeply nested folders

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Folder lookup now checks well-known folder aliases first for faster, more reliable resolution.
  * Discovery searches the full folder tree (including nested folders) rather than only top-level folders.
  * Ambiguous case-insensitive name matches no longer pick a result silently; they fail cleanly to avoid incorrect selection.
  * Folder hierarchy and parent-name mapping are improved so parent relationships display more accurately.
  * Errors fetching nested folders now surface instead of being silently ignored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->