### PR TITLE
Add to/body/subject-or-body conditions to create-rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,8 @@ A comprehensive MCP (Model Context Protocol) server that connects Claude with Mi
 | `create-folder` | Create mail folder |
 | `move-emails` | Move emails between folders |
 | `list-rules` | List inbox rules |
-| `create-rule` | Create inbox rule |
+| `create-rule` | Create inbox rule (conditions: from, to, subject, body, subject-or-body, has attachment) |
+| `edit-rule-sequence` | Change rule execution order |
 
 ### OneDrive
 | Tool | Description |
@@ -161,10 +162,11 @@ npm install
 3. Add these permissions:
    - `offline_access`
    - `User.Read`
-   - `Mail.Read`, `Mail.ReadWrite`, `Mail.Send`
+   - `Mail.Read`, `Mail.ReadWrite`, `Mail.Send` (`Mail.ReadWrite` required for managing inbox rules)
    - `Calendars.Read`, `Calendars.ReadWrite`
    - `Files.Read`, `Files.ReadWrite`
 4. Click "Add permissions"
+5. Click "Grant admin consent for [your organization]" so permissions are pre-approved
 
 **For Power Automate** (optional):
 - Requires additional Azure AD configuration with Flow API scope

--- a/rules/create.js
+++ b/rules/create.js
@@ -16,6 +16,9 @@ async function handleCreateRule(args) {
     name,
     fromAddresses,
     containsSubject,
+    bodyContains,
+    bodyOrSubjectContains,
+    sentToAddresses,
     hasAttachments,
     moveToFolder,
     markAsRead,
@@ -43,7 +46,7 @@ async function handleCreateRule(args) {
   }
   
   // Validate that at least one condition or action is specified
-  const hasCondition = fromAddresses || containsSubject || hasAttachments === true;
+  const hasCondition = fromAddresses || containsSubject || bodyContains || bodyOrSubjectContains || sentToAddresses || hasAttachments === true;
   const hasAction = moveToFolder || markAsRead === true;
   
   if (!hasCondition) {
@@ -73,13 +76,16 @@ async function handleCreateRule(args) {
       name,
       fromAddresses,
       containsSubject,
+      bodyContains,
+      bodyOrSubjectContains,
+      sentToAddresses,
       hasAttachments,
       moveToFolder,
       markAsRead,
       isEnabled,
       sequence
     });
-    
+
     let responseText = result.message;
     
     // Add a tip about sequence if it wasn't provided
@@ -124,6 +130,9 @@ async function createInboxRule(accessToken, ruleOptions) {
       name,
       fromAddresses,
       containsSubject,
+      bodyContains,
+      bodyOrSubjectContains,
+      sentToAddresses,
       hasAttachments,
       moveToFolder,
       markAsRead,
@@ -188,7 +197,25 @@ async function createInboxRule(accessToken, ruleOptions) {
     if (containsSubject) {
       rule.conditions.subjectContains = [containsSubject];
     }
-    
+
+    if (bodyContains) {
+      rule.conditions.bodyContains = [bodyContains];
+    }
+
+    if (bodyOrSubjectContains) {
+      rule.conditions.bodyOrSubjectContains = [bodyOrSubjectContains];
+    }
+
+    if (sentToAddresses) {
+      const toAddresses = sentToAddresses.split(',')
+        .map(email => email.trim())
+        .filter(email => email)
+        .map(email => ({ emailAddress: { address: email } }));
+      if (toAddresses.length > 0) {
+        rule.conditions.sentToAddresses = toAddresses;
+      }
+    }
+
     if (hasAttachments === true) {
       rule.conditions.hasAttachment = true;
     }

--- a/rules/index.js
+++ b/rules/index.js
@@ -117,9 +117,21 @@ const rulesTools = [
           type: "string",
           description: "Comma-separated list of sender email addresses for the rule"
         },
+        sentToAddresses: {
+          type: "string",
+          description: "Comma-separated list of recipient (To) email addresses the email must be sent to"
+        },
         containsSubject: {
           type: "string",
           description: "Subject text the email must contain"
+        },
+        bodyContains: {
+          type: "string",
+          description: "Text the email body must contain"
+        },
+        bodyOrSubjectContains: {
+          type: "string",
+          description: "Text that must appear in either the subject or body of the email"
         },
         hasAttachments: {
           type: "boolean",


### PR DESCRIPTION
Adds three new conditions to the `create-rule` tool:

- `sentToAddresses` — match emails sent to specific recipients (To field)
- `bodyContains` — match emails containing text in the body
- `bodyOrSubjectContains` — match emails containing text in subject or body

Also updates README to clarify `Mail.ReadWrite` is required for inbox rules and adds admin consent step.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for additional email rule conditions: body content matching, combined subject/body content matching, and recipient address filtering.
  * New tool to reorder rule execution sequence.

* **Documentation**
  * Updated rule tool documentation with complete list of supported condition fields.
  * Clarified Azure permissions requirements and added admin consent setup instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->