### PR TITLE
fix: Graph API extraHeaders, calendar timezone, email search improvements

### DIFF
--- a/calendar/index.js
+++ b/calendar/index.js
@@ -2,7 +2,9 @@
  * Calendar module for Outlook MCP server
  */
 const handleListEvents = require('./list');
+const handleAcceptEvent = require('./accept');
 const handleDeclineEvent = require('./decline');
+const handleTentativeEvent = require('./tentative');
 const handleCreateEvent = require('./create');
 const handleCancelEvent = require('./cancel');
 const handleDeleteEvent = require('./delete');
@@ -26,11 +28,53 @@ const calendarTools = [
         endDateTime: {
           type: "string",
           description: "ISO 8601 end date/time for the query range (default: startDateTime + 30 days)"
+        },
+        timezone: {
+          type: "string",
+          description: "IANA timezone for displayed times (e.g. 'Europe/Oslo', 'America/New_York'). Defaults to OUTLOOK_TIMEZONE env var, or UTC if unset."
         }
       },
       required: []
     },
     handler: handleListEvents
+  },
+  {
+    name: "accept-event",
+    description: "Accepts a calendar event",
+    inputSchema: {
+      type: "object",
+      properties: {
+        eventId: {
+          type: "string",
+          description: "The ID of the event to accept"
+        },
+        comment: {
+          type: "string",
+          description: "Optional comment for accepting the event"
+        }
+      },
+      required: ["eventId"]
+    },
+    handler: handleAcceptEvent
+  },
+  {
+    name: "tentative-event",
+    description: "Tentatively accepts a calendar event",
+    inputSchema: {
+      type: "object",
+      properties: {
+        eventId: {
+          type: "string",
+          description: "The ID of the event to tentatively accept"
+        },
+        comment: {
+          type: "string",
+          description: "Optional comment for tentatively accepting the event"
+        }
+      },
+      required: ["eventId"]
+    },
+    handler: handleTentativeEvent
   },
   {
     name: "decline-event",
@@ -124,7 +168,9 @@ const calendarTools = [
 module.exports = {
   calendarTools,
   handleListEvents,
+  handleAcceptEvent,
   handleDeclineEvent,
+  handleTentativeEvent,
   handleCreateEvent,
   handleCancelEvent,
   handleDeleteEvent

--- a/calendar/list.js
+++ b/calendar/list.js
@@ -6,17 +6,40 @@ const { callGraphAPI } = require('../utils/graph-api');
 const { ensureAuthenticated } = require('../auth');
 
 /**
+ * Format a Graph API dateTime string for display.
+ * When Prefer: outlook.timezone header is set, dateTime is in that timezone.
+ * Input: "2026-03-16T18:30:00.0000000" → Output: "3/16/2026, 6:30:00 PM"
+ */
+function formatGraphDateTime(dateTimeStr) {
+  if (!dateTimeStr || !dateTimeStr.includes('T')) return dateTimeStr || 'N/A';
+
+  const [datePart, timePart] = dateTimeStr.split('T');
+  if (!datePart || !timePart) return dateTimeStr;
+
+  const [year, month, day] = datePart.split('-').map(Number);
+  const [hours, minutes] = timePart.split(':').map(Number);
+  if (isNaN(year) || isNaN(hours)) return dateTimeStr;
+
+  const h12 = hours % 12 || 12;
+  const ampm = hours < 12 ? 'AM' : 'PM';
+  const mm = String(minutes).padStart(2, '0');
+
+  return `${month}/${day}/${year}, ${h12}:${mm}:00 ${ampm}`;
+}
+
+/**
  * List events handler
  * @param {object} args - Tool arguments
  * @returns {object} - MCP response
  */
 async function handleListEvents(args) {
   const count = Math.min(args.count || 10, config.MAX_RESULT_COUNT);
-  
+  const timezone = args.timezone || config.DISPLAY_TIMEZONE;
+
   try {
     // Get access token
     const accessToken = await ensureAuthenticated();
-    
+
     // Use calendarView endpoint to include expanded recurring event instances
     const startDate = args.startDateTime ? new Date(args.startDateTime) : new Date();
     const endDate = args.endDateTime
@@ -43,87 +66,53 @@ async function handleListEvents(args) {
       $select: config.CALENDAR_SELECT_FIELDS
     };
 
+    // Request times in the specified timezone so dateTime values are local
+    const extraHeaders = timezone
+      ? { 'Prefer': `outlook.timezone="${timezone}"` }
+      : {};
+
     // Make API call
-    const response = await callGraphAPI(accessToken, 'GET', endpoint, null, queryParams);
-    
+    const response = await callGraphAPI(accessToken, 'GET', endpoint, null, queryParams, extraHeaders);
+
     if (!response.value || response.value.length === 0) {
       return {
-        content: [{ 
-          type: "text", 
+        content: [{
+          type: "text",
           text: "No calendar events found."
         }]
       };
     }
-    
-    // Detect system timezone
-    const systemTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-    
+
     // Format results
+    // Note: With Prefer: outlook.timezone header, Graph API returns dateTime in the requested timezone.
+    // Do NOT pass it through new Date() which would treat it as UTC and shift it.
     const eventList = response.value.map((event, index) => {
-      const formatDateTime = (dateTimeData) => {
-        // Defensive checks: handle null/undefined and string inputs
-        if (!dateTimeData) return '';
-        const dateTime = typeof dateTimeData === 'string' ? dateTimeData : (dateTimeData.dateTime || '');
-        const timeZone = typeof dateTimeData === 'object' ? dateTimeData.timeZone : undefined;
-        if (!dateTime) return '';
-
-        // Detect if the string already contains timezone info (Z or +/-HH:MM)
-        const hasOffset = /[zZ]$|[+\-]\d{2}:\d{2}$/.test(dateTime);
-
-        // Helper to format a valid Date using the detected system timezone only if available
-        const formatDateObj = (date) => {
-          if (isNaN(date.getTime())) return dateTime;
-          const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
-          const options = {
-            year: 'numeric',
-            month: 'long',
-            day: 'numeric',
-            hour: 'numeric',
-            minute: '2-digit',
-            hour12: true
-          };
-          if (tz) options.timeZone = tz;
-          return date.toLocaleString('en-US', options);
-        };
-
-        // If it's UTC or has explicit offset, parse safely
-        if (timeZone === 'UTC' || hasOffset || !timeZone) {
-          const iso = dateTime.endsWith('Z') || hasOffset ? dateTime : dateTime + 'Z';
-          const date = new Date(iso);
-          return formatDateObj(date);
-        }
-
-        // If there's a specific timezone but the string lacks an offset, we cannot reliably convert without a timezone-aware library.
-        // Return a clear fallback that includes the original timezone so we avoid silently showing an incorrect local time.
-        return `${dateTime} (${timeZone})`;
-      };
-
-      const startDate = formatDateTime(event.start);
-      const endDate = formatDateTime(event.end);
+      const startDate = formatGraphDateTime(event.start?.dateTime || '');
+      const endDate = formatGraphDateTime(event.end?.dateTime || '');
       const location = event.location?.displayName || 'No location';
-      
+
       return `${index + 1}. ${event.subject} - Location: ${location}\nStart: ${startDate}\nEnd: ${endDate}\nSummary: ${event.bodyPreview}\nID: ${event.id}\n`;
     }).join("\n");
 
     return {
-      content: [{ 
-        type: "text", 
+      content: [{
+        type: "text",
         text: `Found ${response.value.length} events:\n\n${eventList}`
       }]
     };
   } catch (error) {
     if (error.message === 'Authentication required') {
       return {
-        content: [{ 
-          type: "text", 
+        content: [{
+          type: "text",
           text: "Authentication required. Please use the 'authenticate' tool first."
         }]
       };
     }
-    
+
     return {
-      content: [{ 
-        type: "text", 
+      content: [{
+        type: "text",
         text: `Error listing events: ${error.message}`
       }]
     };

--- a/calendar/tentative.js
+++ b/calendar/tentative.js
@@ -1,0 +1,64 @@
+/**
+ * Tentatively accept event functionality
+ */
+const { callGraphAPI } = require('../utils/graph-api');
+const { ensureAuthenticated } = require('../auth');
+
+/**
+ * Tentatively accept event handler
+ * @param {object} args - Tool arguments
+ * @returns {object} - MCP response
+ */
+async function handleTentativeEvent(args) {
+  const { eventId, comment } = args;
+
+  if (!eventId) {
+    return {
+      content: [{
+        type: "text",
+        text: "Event ID is required to tentatively accept an event."
+      }]
+    };
+  }
+
+  try {
+    // Get access token
+    const accessToken = await ensureAuthenticated();
+
+    // Build API endpoint
+    const endpoint = `me/events/${eventId}/tentativelyAccept`;
+
+    // Request body
+    const body = {
+      comment: comment || "Tentatively accepted via API"
+    };
+
+    // Make API call
+    await callGraphAPI(accessToken, 'POST', endpoint, body);
+
+    return {
+      content: [{
+        type: "text",
+        text: `Event with ID ${eventId} has been tentatively accepted.`
+      }]
+    };
+  } catch (error) {
+    if (error.message === 'Authentication required' || error.message === 'UNAUTHORIZED') {
+      return {
+        content: [{
+          type: "text",
+          text: "Authentication required. Please use the 'authenticate' tool first."
+        }]
+      };
+    }
+
+    return {
+      content: [{
+        type: "text",
+        text: `Error tentatively accepting event: ${error.message}`
+      }]
+    };
+  }
+}
+
+module.exports = handleTentativeEvent;

--- a/config.js
+++ b/config.js
@@ -43,7 +43,13 @@ module.exports = {
   MAX_RESULT_COUNT: 50,
 
   // Timezone
+  // Windows timezone for creating events via Graph API
   DEFAULT_TIMEZONE: "Central European Standard Time",
+  // IANA timezone for display (used in Prefer: outlook.timezone header)
+  // Set OUTLOOK_TIMEZONE env var (e.g. "Europe/Oslo") to send the
+  // Prefer: outlook.timezone header with calendar requests.
+  // When empty, times are returned in UTC.
+  DISPLAY_TIMEZONE: process.env.OUTLOOK_TIMEZONE || "",
 
   // OneDrive constants
   ONEDRIVE_SELECT_FIELDS: 'id,name,size,lastModifiedDateTime,webUrl,folder,file,parentReference',

--- a/email/folder-utils.js
+++ b/email/folder-utils.js
@@ -13,6 +13,7 @@ const folderCache = {};
  * Well-known folder names and their endpoints
  */
 const WELL_KNOWN_FOLDERS = {
+  'all': 'me/messages',
   'inbox': 'me/mailFolders/inbox/messages',
   'drafts': 'me/mailFolders/drafts/messages',
   'sent': 'me/mailFolders/sentItems/messages',

--- a/email/search.js
+++ b/email/search.js
@@ -1,16 +1,22 @@
 /**
- * Improved search emails functionality
+ * Search emails functionality
+ *
+ * Microsoft Graph API constraints:
+ * - $search: plain text keywords only, no KQL field:value, no $orderby/$filter
+ * - $filter: structured filters on properties like from, hasAttachments, isRead
+ * - $filter on from/to requires ConsistencyLevel: eventual header + $count=true
+ * - $search and $filter CANNOT be combined
+ *
+ * Strategy:
+ * 1. from/to specified → use $filter with advanced query headers, client-side text filter
+ * 2. Only text query/subject → use $search
+ * 3. Only boolean filters → use $filter
  */
 const config = require('../config');
 const { callGraphAPI, callGraphAPIPaginated } = require('../utils/graph-api');
 const { ensureAuthenticated } = require('../auth');
 const { resolveFolderPath } = require('./folder-utils');
 
-/**
- * Search emails handler
- * @param {object} args - Tool arguments
- * @returns {object} - MCP response
- */
 async function handleSearchEmails(args) {
   const folder = args.folder || "inbox";
   const requestedCount = args.count || 10;
@@ -20,286 +26,145 @@ async function handleSearchEmails(args) {
   const subject = args.subject || '';
   const hasAttachments = args.hasAttachments;
   const unreadOnly = args.unreadOnly;
-  
+
   try {
-    // Get access token
     const accessToken = await ensureAuthenticated();
-    
-    // Resolve the folder path
     const endpoint = await resolveFolderPath(accessToken, folder);
     console.error(`Using endpoint: ${endpoint} for folder: ${folder}`);
-    
-    // Execute progressive search with pagination
-    const response = await progressiveSearch(
-      endpoint, 
-      accessToken, 
-      { query, from, to, subject },
-      { hasAttachments, unreadOnly },
-      requestedCount
-    );
-    
+
+    const hasStructuredFilter = !!(from || to);
+    const hasTextSearch = !!(query || subject);
+    const hasBooleanFilter = hasAttachments === true || unreadOnly === true;
+
+    const params = {
+      $select: config.EMAIL_SELECT_FIELDS
+    };
+    let extraHeaders = {};
+    let clientSideTextFilter = null;
+
+    if (hasStructuredFilter) {
+      // Use $filter with advanced query for from/to
+      const filterConditions = [];
+      if (from) filterConditions.push(`from/emailAddress/address eq '${from}'`);
+      if (to) filterConditions.push(`toRecipients/any(r:r/emailAddress/address eq '${to}')`);
+      if (hasAttachments === true) filterConditions.push('hasAttachments eq true');
+      if (unreadOnly === true) filterConditions.push('isRead eq false');
+
+      params.$filter = filterConditions.join(' and ');
+      params.$count = 'true';
+      params.$top = 50;
+      extraHeaders = { 'ConsistencyLevel': 'eventual' };
+
+      // Text search will be done client-side
+      if (hasTextSearch) {
+        clientSideTextFilter = { query, subject };
+      }
+    } else if (hasTextSearch) {
+      // Use $search for text queries (no $orderby allowed)
+      const searchTerms = [];
+      if (query) searchTerms.push(`"${query}"`);
+      if (subject) searchTerms.push(`"${subject}"`);
+      params.$search = searchTerms.join(' ');
+      params.$top = Math.min(50, requestedCount);
+
+      // Boolean filters done client-side since $search + $filter not allowed
+      if (hasBooleanFilter) {
+        params.$top = 50;
+      }
+    } else if (hasBooleanFilter) {
+      // Only boolean filters
+      const filterConditions = [];
+      if (hasAttachments === true) filterConditions.push('hasAttachments eq true');
+      if (unreadOnly === true) filterConditions.push('isRead eq false');
+      params.$filter = filterConditions.join(' and ');
+      params.$orderby = 'receivedDateTime desc';
+      params.$top = Math.min(50, requestedCount);
+    } else {
+      // No criteria — recent emails
+      params.$orderby = 'receivedDateTime desc';
+      params.$top = Math.min(50, requestedCount);
+    }
+
+    console.error("Search params:", JSON.stringify(params, null, 2));
+    if (clientSideTextFilter) console.error("Client-side text filter:", JSON.stringify(clientSideTextFilter));
+    if (Object.keys(extraHeaders).length > 0) console.error("Extra headers:", JSON.stringify(extraHeaders));
+
+    const fetchCount = (hasStructuredFilter || (hasTextSearch && hasBooleanFilter))
+      ? Math.max(requestedCount * 5, 50)
+      : requestedCount;
+
+    const response = await callGraphAPIPaginated(accessToken, 'GET', endpoint, params, fetchCount, extraHeaders);
+    console.error(`API returned ${response.value?.length || 0} results`);
+
+    // Client-side text filtering (when $filter was used instead of $search)
+    if (clientSideTextFilter && response.value) {
+      const q = (clientSideTextFilter.query || '').toLowerCase();
+      const s = (clientSideTextFilter.subject || '').toLowerCase();
+      response.value = response.value.filter(email => {
+        const emailSubject = (email.subject || '').toLowerCase();
+        const emailPreview = (email.bodyPreview || '').toLowerCase();
+        if (q && !emailSubject.includes(q) && !emailPreview.includes(q)) return false;
+        if (s && !emailSubject.includes(s)) return false;
+        return true;
+      });
+      console.error(`After text filtering: ${response.value.length} results`);
+    }
+
+    // Client-side boolean filtering (when $search was used instead of $filter)
+    if (hasTextSearch && !hasStructuredFilter && hasBooleanFilter && response.value) {
+      response.value = response.value.filter(email => {
+        if (hasAttachments === true && !email.hasAttachments) return false;
+        if (unreadOnly === true && email.isRead) return false;
+        return true;
+      });
+      console.error(`After boolean filtering: ${response.value.length} results`);
+    }
+
+    // Trim to requested count
+    if (response.value && response.value.length > requestedCount) {
+      response.value = response.value.slice(0, requestedCount);
+    }
+
     return formatSearchResults(response);
   } catch (error) {
-    // Handle authentication errors
     if (error.message === 'Authentication required') {
       return {
-        content: [{ 
-          type: "text", 
+        content: [{
+          type: "text",
           text: "Authentication required. Please use the 'authenticate' tool first."
         }]
       };
     }
-    
-    // General error response
     return {
-      content: [{ 
-        type: "text", 
+      content: [{
+        type: "text",
         text: `Error searching emails: ${error.message}`
       }]
     };
   }
 }
 
-/**
- * Execute a search with progressively simpler fallback strategies
- * @param {string} endpoint - API endpoint
- * @param {string} accessToken - Access token
- * @param {object} searchTerms - Search terms (query, from, to, subject)
- * @param {object} filterTerms - Filter terms (hasAttachments, unreadOnly)
- * @param {number} maxCount - Maximum number of results to retrieve
- * @returns {Promise<object>} - Search results
- */
-async function progressiveSearch(endpoint, accessToken, searchTerms, filterTerms, maxCount) {
-  // Track search strategies attempted
-  const searchAttempts = [];
-  
-  // 1. Try combined search (most specific)
-  try {
-    const params = buildSearchParams(searchTerms, filterTerms, Math.min(50, maxCount));
-    console.error("Attempting combined search with params:", params);
-    searchAttempts.push("combined-search");
-    
-    const response = await callGraphAPIPaginated(accessToken, 'GET', endpoint, params, maxCount);
-    if (response.value && response.value.length > 0) {
-      console.error(`Combined search successful: found ${response.value.length} results`);
-      return response;
-    }
-  } catch (error) {
-    console.error(`Combined search failed: ${error.message}`);
-  }
-  
-  // 2. Try each search term individually, starting with most specific
-  const searchPriority = ['subject', 'from', 'to', 'query'];
-  
-  for (const term of searchPriority) {
-    if (searchTerms[term]) {
-      try {
-        console.error(`Attempting search with only ${term}: "${searchTerms[term]}"`);
-        searchAttempts.push(`single-term-${term}`);
-        
-        // For single term search, only use $search with that term
-        // Graph API does not support $orderby or $filter with $search
-        const simplifiedParams = {
-          $top: Math.min(50, maxCount),
-          $select: config.EMAIL_SELECT_FIELDS
-        };
-        
-        // Build KQL terms for search
-        const kqlParts = [];
-        
-        // Add the search term in the appropriate KQL syntax
-        if (term === 'query') {
-          // General query doesn't need a prefix
-          kqlParts.push(searchTerms[term]);
-        } else {
-          // Specific field searches use field:value syntax
-          kqlParts.push(`${term}:${searchTerms[term]}`);
-        }
-        
-        // Add boolean filters as KQL (can't use $filter with $search)
-        addBooleanFiltersAsKQL(kqlParts, filterTerms);
-        
-        simplifiedParams.$search = `"${kqlParts.join(' ')}"`;
-        
-        const response = await callGraphAPIPaginated(accessToken, 'GET', endpoint, simplifiedParams, maxCount);
-        if (response.value && response.value.length > 0) {
-          console.error(`Search with ${term} successful: found ${response.value.length} results`);
-          return response;
-        }
-      } catch (error) {
-        console.error(`Search with ${term} failed: ${error.message}`);
-      }
-    }
-  }
-  
-  // 3. Try with only boolean filters
-  if (filterTerms.hasAttachments === true || filterTerms.unreadOnly === true) {
-    try {
-      console.error("Attempting search with only boolean filters");
-      searchAttempts.push("boolean-filters-only");
-      
-      const filterOnlyParams = {
-        $top: Math.min(50, maxCount),
-        $select: config.EMAIL_SELECT_FIELDS,
-        $orderby: 'receivedDateTime desc'
-      };
-      
-      // Add the boolean filters
-      addBooleanFilters(filterOnlyParams, filterTerms);
-      
-      const response = await callGraphAPIPaginated(accessToken, 'GET', endpoint, filterOnlyParams, maxCount);
-      console.error(`Boolean filter search found ${response.value?.length || 0} results`);
-      return response;
-    } catch (error) {
-      console.error(`Boolean filter search failed: ${error.message}`);
-    }
-  }
-  
-  // 4. Final fallback: just get recent emails with pagination
-  console.error("All search strategies failed, falling back to recent emails");
-  searchAttempts.push("recent-emails");
-  
-  const basicParams = {
-    $top: Math.min(50, maxCount),
-    $select: config.EMAIL_SELECT_FIELDS,
-    $orderby: 'receivedDateTime desc'
-  };
-  
-  const response = await callGraphAPIPaginated(accessToken, 'GET', endpoint, basicParams, maxCount);
-  console.error(`Fallback to recent emails found ${response.value?.length || 0} results`);
-  
-  // Add a note to the response about the search attempts
-  response._searchInfo = {
-    attemptsCount: searchAttempts.length,
-    strategies: searchAttempts,
-    originalTerms: searchTerms,
-    filterTerms: filterTerms
-  };
-  
-  return response;
-}
-
-/**
- * Build search parameters from search terms and filter terms
- * @param {object} searchTerms - Search terms (query, from, to, subject)
- * @param {object} filterTerms - Filter terms (hasAttachments, unreadOnly)
- * @param {number} count - Maximum number of results
- * @returns {object} - Query parameters
- */
-function buildSearchParams(searchTerms, filterTerms, count) {
-  const params = {
-    $top: count,
-    $select: config.EMAIL_SELECT_FIELDS
-  };
-  
-  // Handle search terms
-  const kqlTerms = [];
-  
-  if (searchTerms.query) {
-    // General query doesn't need a prefix
-    kqlTerms.push(searchTerms.query);
-  }
-  
-  if (searchTerms.subject) {
-    kqlTerms.push(`subject:\"${searchTerms.subject}\"`);
-  }
-
-  if (searchTerms.from) {
-    kqlTerms.push(`from:\"${searchTerms.from}\"`);
-  }
-
-  if (searchTerms.to) {
-    kqlTerms.push(`to:\"${searchTerms.to}\"`);
-  }
-  
-  // Add $search if we have any search terms
-  if (kqlTerms.length > 0) {
-    // Graph API does not support $orderby or $filter with $search
-    // Move boolean filters into KQL syntax instead
-    addBooleanFiltersAsKQL(kqlTerms, filterTerms);
-    params.$search = `"${kqlTerms.join(' ')}"`;
-  } else {
-    // No search terms — safe to use $orderby and $filter
-    params.$orderby = 'receivedDateTime desc';
-    addBooleanFilters(params, filterTerms);
-  }
-  
-  return params;
-}
-
-/**
- * Add boolean filters to query parameters as OData $filter
- * Only use when $search is NOT present (they conflict in Graph API)
- * @param {object} params - Query parameters
- * @param {object} filterTerms - Filter terms (hasAttachments, unreadOnly)
- */
-function addBooleanFilters(params, filterTerms) {
-  const filterConditions = [];
-  
-  if (filterTerms.hasAttachments === true) {
-    filterConditions.push('hasAttachments eq true');
-  }
-  
-  if (filterTerms.unreadOnly === true) {
-    filterConditions.push('isRead eq false');
-  }
-  
-  // Add $filter parameter if we have any filter conditions
-  if (filterConditions.length > 0) {
-    params.$filter = filterConditions.join(' and ');
-  }
-}
-
-/**
- * Add boolean filters as KQL terms for use with $search
- * Use this instead of addBooleanFilters when $search is present
- * @param {string[]} kqlTerms - Array of KQL terms to append to
- * @param {object} filterTerms - Filter terms (hasAttachments, unreadOnly)
- */
-function addBooleanFiltersAsKQL(kqlTerms, filterTerms) {
-  if (filterTerms.hasAttachments === true) {
-    kqlTerms.push('hasAttachments:true');
-  }
-  
-  if (filterTerms.unreadOnly === true) {
-    kqlTerms.push('isRead:false');
-  }
-}
-
-/**
- * Format search results into a readable text format
- * @param {object} response - The API response object
- * @returns {object} - MCP response object
- */
 function formatSearchResults(response) {
   if (!response.value || response.value.length === 0) {
     return {
-      content: [{ 
-        type: "text", 
+      content: [{
+        type: "text",
         text: `No emails found matching your search criteria.`
       }]
     };
   }
-  
-  // Format results
+
   const emailList = response.value.map((email, index) => {
     const sender = email.from?.emailAddress || { name: 'Unknown', address: 'unknown' };
     const date = new Date(email.receivedDateTime).toLocaleString();
     const readStatus = email.isRead ? '' : '[UNREAD] ';
-    
     return `${index + 1}. ${readStatus}${date} - From: ${sender.name} (${sender.address})\nSubject: ${email.subject}\nID: ${email.id}\n`;
   }).join("\n");
-  
-  // Add search strategy info if available
-  let additionalInfo = '';
-  if (response._searchInfo) {
-    additionalInfo = `\n(Search used ${response._searchInfo.strategies[response._searchInfo.strategies.length - 1]} strategy)`;
-  }
-  
+
   return {
-    content: [{ 
-      type: "text", 
-      text: `Found ${response.value.length} emails matching your search criteria:${additionalInfo}\n\n${emailList}`
+    content: [{
+      type: "text",
+      text: `Found ${response.value.length} emails matching your search criteria:\n\n${emailList}`
     }]
   };
 }

--- a/utils/graph-api.js
+++ b/utils/graph-api.js
@@ -14,7 +14,7 @@ const mockData = require('./mock-data');
  * @param {object} queryParams - Query parameters
  * @returns {Promise<object>} - The API response
  */
-async function callGraphAPI(accessToken, method, path, data = null, queryParams = {}) {
+async function callGraphAPI(accessToken, method, path, data = null, queryParams = {}, extraHeaders = {}) {
   // For test tokens, we'll simulate the API call
   if (config.USE_TEST_MODE && accessToken.startsWith('test_access_token_')) {
     console.error(`TEST MODE: Simulating ${method} ${path} API call`);
@@ -40,26 +40,39 @@ async function callGraphAPI(accessToken, method, path, data = null, queryParams 
       // Build query string from parameters with special handling for OData filters
       let queryString = '';
       if (Object.keys(queryParams).length > 0) {
-        // Handle $filter parameter specially to ensure proper URI encoding
+        // Handle $filter and $search parameters specially to ensure proper URI encoding
         const filter = queryParams.$filter;
+        const search = queryParams.$search;
         if (filter) {
-          delete queryParams.$filter; // Remove from regular params
+          delete queryParams.$filter;
         }
-        
+        if (search) {
+          delete queryParams.$search;
+        }
+
         // Build query string with proper encoding for regular params
         const params = new URLSearchParams();
         for (const [key, value] of Object.entries(queryParams)) {
           params.append(key, value);
         }
-        
+
         queryString = params.toString();
-        
+
         // Add filter parameter separately with proper encoding
         if (filter) {
           if (queryString) {
             queryString += `&$filter=${encodeURIComponent(filter)}`;
           } else {
             queryString = `$filter=${encodeURIComponent(filter)}`;
+          }
+        }
+
+        // Add search parameter separately with proper encoding
+        if (search) {
+          if (queryString) {
+            queryString += `&$search=${encodeURIComponent(search)}`;
+          } else {
+            queryString = `$search=${encodeURIComponent(search)}`;
           }
         }
         
@@ -79,7 +92,8 @@ async function callGraphAPI(accessToken, method, path, data = null, queryParams 
         method: method,
         headers: {
           'Authorization': `Bearer ${accessToken}`,
-          'Content-Type': 'application/json'
+          'Content-Type': 'application/json',
+          ...extraHeaders
         }
       };
       
@@ -133,7 +147,7 @@ async function callGraphAPI(accessToken, method, path, data = null, queryParams 
  * @param {number} maxCount - Maximum number of items to retrieve (0 = all)
  * @returns {Promise<object>} - Combined API response with all items
  */
-async function callGraphAPIPaginated(accessToken, method, path, queryParams = {}, maxCount = 0) {
+async function callGraphAPIPaginated(accessToken, method, path, queryParams = {}, maxCount = 0, extraHeaders = {}) {
   if (method !== 'GET') {
     throw new Error('Pagination only supports GET requests');
   }
@@ -146,7 +160,7 @@ async function callGraphAPIPaginated(accessToken, method, path, queryParams = {}
   try {
     do {
       // Make API call
-      const response = await callGraphAPI(accessToken, method, currentUrl, null, currentParams);
+      const response = await callGraphAPI(accessToken, method, currentUrl, null, currentParams, extraHeaders);
       
       // Add items from this page
       if (response.value && Array.isArray(response.value)) {


### PR DESCRIPTION
## Summary
- **Graph API:** Add `extraHeaders` support and `$search` encoding to `callGraphAPI()` — needed for `Prefer: outlook.timezone` and `ConsistencyLevel: eventual` headers
- **Calendar:** Use `Prefer: outlook.timezone` header for correct local time display, add `tentative-event` tool, add `timezone` parameter to `list-events`
- **Email search:** Rewrite to properly handle Graph API constraints (`$search` and `$filter` can't be combined), default search folder back to inbox

## Test plan
- [x] Verify calendar events show times in correct timezone when `OUTLOOK_TIMEZONE` is set
- [x] Verify `tentative-event` tool works for calendar RSVPs
- [x] Verify email search works with `from`, `subject`, `query` filters
- [x] Verify search defaults to inbox folder

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Respond to calendar events with Accept or Tentative responses, including optional comments
  * New "All" mailbox view to access every message

* **Improvements**
  * Calendar event times respect a configurable display timezone
  * Email search rewritten for smarter filtering, improved relevancy, and consistent pagination/counts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->