### PR TITLE
feat(calendar): surface showAs/isAllDay, add update-event, recurrence

### DIFF
--- a/calendar/create.js
+++ b/calendar/create.js
@@ -4,14 +4,17 @@
 const { callGraphAPI } = require('../utils/graph-api');
 const { ensureAuthenticated } = require('../auth');
 const { DEFAULT_TIMEZONE } = require('../config');
+const { validateRecurrence } = require('./recurrence');
 
 /**
  * Create event handler
  * @param {object} args - Tool arguments
  * @returns {object} - MCP response
  */
+const ALLOWED_SHOW_AS = ['free', 'tentative', 'busy', 'oof', 'workingElsewhere', 'unknown'];
+
 async function handleCreateEvent(args) {
-  const { subject, start, end, attendees, body } = args;
+  const { subject, start, end, attendees, body, isAllDay, showAs, recurrence } = args;
 
   if (!subject || !start || !end) {
     return {
@@ -20,6 +23,35 @@ async function handleCreateEvent(args) {
         text: "Subject, start, and end times are required to create an event."
       }]
     };
+  }
+
+  if (showAs !== undefined && !ALLOWED_SHOW_AS.includes(showAs)) {
+    return {
+      content: [{
+        type: "text",
+        text: `Invalid showAs value '${showAs}'. Must be one of: ${ALLOWED_SHOW_AS.join(', ')}.`
+      }]
+    };
+  }
+
+  const recurrenceCheck = validateRecurrence(recurrence);
+  if (!recurrenceCheck.ok) {
+    return { content: [{ type: "text", text: recurrenceCheck.error }] };
+  }
+
+  const startDateTime = start.dateTime || start;
+  const endDateTime = end.dateTime || end;
+
+  if (isAllDay === true) {
+    const isMidnight = (dt) => typeof dt === 'string' && /T00:00(:00(\.0+)?)?$/.test(dt.replace(/[zZ]$|[+\-]\d{2}:\d{2}$/, ''));
+    if (!isMidnight(startDateTime) || !isMidnight(endDateTime)) {
+      return {
+        content: [{
+          type: "text",
+          text: "All-day events require start and end to be at midnight (e.g. '2026-04-14T00:00:00') in the supplied timeZone."
+        }]
+      };
+    }
   }
 
   try {
@@ -32,11 +64,15 @@ async function handleCreateEvent(args) {
     // Request body
     const bodyContent = {
       subject,
-      start: { dateTime: start.dateTime || start, timeZone: start.timeZone || DEFAULT_TIMEZONE },
-      end: { dateTime: end.dateTime || end, timeZone: end.timeZone || DEFAULT_TIMEZONE },
+      start: { dateTime: startDateTime, timeZone: start.timeZone || DEFAULT_TIMEZONE },
+      end: { dateTime: endDateTime, timeZone: end.timeZone || DEFAULT_TIMEZONE },
       attendees: attendees?.map(email => ({ emailAddress: { address: email }, type: "required" })),
       body: { contentType: "HTML", content: body || "" }
     };
+
+    if (isAllDay === true) bodyContent.isAllDay = true;
+    if (showAs !== undefined) bodyContent.showAs = showAs;
+    if (recurrence !== undefined) bodyContent.recurrence = recurrence;
 
     // Make API call
     const response = await callGraphAPI(accessToken, 'POST', endpoint, bodyContent);

--- a/calendar/index.js
+++ b/calendar/index.js
@@ -4,8 +4,10 @@
 const handleListEvents = require('./list');
 const handleDeclineEvent = require('./decline');
 const handleCreateEvent = require('./create');
+const handleUpdateEvent = require('./update');
 const handleCancelEvent = require('./cancel');
 const handleDeleteEvent = require('./delete');
+const { RECURRENCE_SCHEMA } = require('./recurrence');
 
 // Calendar tool definitions
 const calendarTools = [
@@ -79,11 +81,71 @@ const calendarTools = [
         body: {
           type: "string",
           description: "Optional body content for the event"
-        }
+        },
+        isAllDay: {
+          type: "boolean",
+          description: "Mark this event as an all-day event. Requires start/end to be at midnight in the supplied timeZone."
+        },
+        showAs: {
+          type: "string",
+          enum: ["free", "tentative", "busy", "oof", "workingElsewhere", "unknown"],
+          description: "Free/busy status to publish for this event (default: busy)"
+        },
+        recurrence: RECURRENCE_SCHEMA
       },
       required: ["subject", "start", "end"]
     },
     handler: handleCreateEvent
+  },
+  {
+    name: "update-event",
+    description: "Updates fields on an existing calendar event. Only provided fields are patched.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        eventId: {
+          type: "string",
+          description: "The ID of the event to update"
+        },
+        subject: {
+          type: "string",
+          description: "New subject for the event"
+        },
+        start: {
+          type: "string",
+          description: "New start time in ISO 8601 format"
+        },
+        end: {
+          type: "string",
+          description: "New end time in ISO 8601 format"
+        },
+        location: {
+          type: "string",
+          description: "New location display name"
+        },
+        attendees: {
+          type: "array",
+          items: { type: "string" },
+          description: "Replacement list of attendee email addresses (replaces the existing list)"
+        },
+        body: {
+          type: "string",
+          description: "New body content (HTML)"
+        },
+        isAllDay: {
+          type: "boolean",
+          description: "Mark this event as all-day. If true, any provided start/end must be at midnight in the supplied timeZone."
+        },
+        showAs: {
+          type: "string",
+          enum: ["free", "tentative", "busy", "oof", "workingElsewhere", "unknown"],
+          description: "Free/busy status to publish for this event"
+        },
+        recurrence: RECURRENCE_SCHEMA
+      },
+      required: ["eventId"]
+    },
+    handler: handleUpdateEvent
   },
   {
     name: "cancel-event",
@@ -126,6 +188,7 @@ module.exports = {
   handleListEvents,
   handleDeclineEvent,
   handleCreateEvent,
+  handleUpdateEvent,
   handleCancelEvent,
   handleDeleteEvent
 };

--- a/calendar/list.js
+++ b/calendar/list.js
@@ -98,11 +98,24 @@ async function handleListEvents(args) {
         return `${dateTime} (${timeZone})`;
       };
 
-      const startDate = formatDateTime(event.start);
-      const endDate = formatDateTime(event.end);
+      const formatAllDay = (dateTimeData) => {
+        if (!dateTimeData) return '';
+        const dateTime = typeof dateTimeData === 'string' ? dateTimeData : (dateTimeData.dateTime || '');
+        if (!dateTime) return '';
+        const datePart = dateTime.split('T')[0];
+        const parsed = new Date(datePart + 'T00:00:00Z');
+        if (isNaN(parsed.getTime())) return datePart;
+        return parsed.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric', timeZone: 'UTC' });
+      };
+
+      const isAllDay = event.isAllDay === true;
+      const startDate = isAllDay ? formatAllDay(event.start) : formatDateTime(event.start);
+      const endDate = isAllDay ? formatAllDay(event.end) : formatDateTime(event.end);
       const location = event.location?.displayName || 'No location';
-      
-      return `${index + 1}. ${event.subject} - Location: ${location}\nStart: ${startDate}\nEnd: ${endDate}\nSummary: ${event.bodyPreview}\nID: ${event.id}\n`;
+      const subjectLine = isAllDay ? `${event.subject} [All day]` : event.subject;
+      const statusLine = event.showAs ? `\nStatus: ${event.showAs}` : '';
+
+      return `${index + 1}. ${subjectLine} - Location: ${location}\nStart: ${startDate}\nEnd: ${endDate}${statusLine}\nSummary: ${event.bodyPreview}\nID: ${event.id}\n`;
     }).join("\n");
 
     return {

--- a/calendar/recurrence.js
+++ b/calendar/recurrence.js
@@ -1,0 +1,88 @@
+/**
+ * Recurrence validation for calendar events.
+ * Mirrors Microsoft Graph's patternedRecurrence shape:
+ *   { pattern: { type, interval, ... }, range: { type, startDate, ... } }
+ */
+
+const PATTERN_TYPES = [
+  'daily',
+  'weekly',
+  'absoluteMonthly',
+  'relativeMonthly',
+  'absoluteYearly',
+  'relativeYearly'
+];
+
+const RANGE_TYPES = ['endDate', 'noEnd', 'numbered'];
+
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
+
+function validateRecurrence(recurrence) {
+  if (recurrence === undefined || recurrence === null) return { ok: true };
+  if (typeof recurrence !== 'object') {
+    return { ok: false, error: "recurrence must be an object with 'pattern' and 'range'." };
+  }
+
+  const { pattern, range } = recurrence;
+  if (!pattern || typeof pattern !== 'object') {
+    return { ok: false, error: "recurrence.pattern is required." };
+  }
+  if (!PATTERN_TYPES.includes(pattern.type)) {
+    return { ok: false, error: `recurrence.pattern.type must be one of: ${PATTERN_TYPES.join(', ')}.` };
+  }
+  if (typeof pattern.interval !== 'number' || pattern.interval < 1) {
+    return { ok: false, error: "recurrence.pattern.interval must be a positive integer." };
+  }
+
+  if (!range || typeof range !== 'object') {
+    return { ok: false, error: "recurrence.range is required." };
+  }
+  if (!RANGE_TYPES.includes(range.type)) {
+    return { ok: false, error: `recurrence.range.type must be one of: ${RANGE_TYPES.join(', ')}.` };
+  }
+  if (!ISO_DATE.test(range.startDate || '')) {
+    return { ok: false, error: "recurrence.range.startDate must be 'YYYY-MM-DD'." };
+  }
+  if (range.type === 'endDate' && !ISO_DATE.test(range.endDate || '')) {
+    return { ok: false, error: "recurrence.range.endDate must be 'YYYY-MM-DD' when range.type is 'endDate'." };
+  }
+  if (range.type === 'numbered' && (typeof range.numberOfOccurrences !== 'number' || range.numberOfOccurrences < 1)) {
+    return { ok: false, error: "recurrence.range.numberOfOccurrences must be a positive integer when range.type is 'numbered'." };
+  }
+
+  return { ok: true };
+}
+
+const RECURRENCE_SCHEMA = {
+  type: "object",
+  description: "Graph patternedRecurrence. Example: {\"pattern\":{\"type\":\"weekly\",\"interval\":1,\"daysOfWeek\":[\"monday\"]},\"range\":{\"type\":\"endDate\",\"startDate\":\"2026-04-14\",\"endDate\":\"2026-07-14\"}}",
+  properties: {
+    pattern: {
+      type: "object",
+      properties: {
+        type: { type: "string", enum: PATTERN_TYPES },
+        interval: { type: "number" },
+        daysOfWeek: { type: "array", items: { type: "string" } },
+        dayOfMonth: { type: "number" },
+        month: { type: "number" },
+        firstDayOfWeek: { type: "string" },
+        index: { type: "string" }
+      },
+      required: ["type", "interval"]
+    },
+    range: {
+      type: "object",
+      properties: {
+        type: { type: "string", enum: RANGE_TYPES },
+        startDate: { type: "string", description: "YYYY-MM-DD" },
+        endDate: { type: "string", description: "YYYY-MM-DD (required when range.type is 'endDate')" },
+        numberOfOccurrences: { type: "number" },
+        recurrenceTimeZone: { type: "string" }
+      },
+      required: ["type", "startDate"]
+    }
+  },
+  required: ["pattern", "range"]
+};
+
+module.exports = { validateRecurrence, RECURRENCE_SCHEMA };

--- a/calendar/update.js
+++ b/calendar/update.js
@@ -1,0 +1,101 @@
+/**
+ * Update event functionality
+ */
+const { callGraphAPI } = require('../utils/graph-api');
+const { ensureAuthenticated } = require('../auth');
+const { DEFAULT_TIMEZONE } = require('../config');
+const { validateRecurrence } = require('./recurrence');
+
+const ALLOWED_SHOW_AS = ['free', 'tentative', 'busy', 'oof', 'workingElsewhere', 'unknown'];
+
+const isMidnight = (dt) =>
+  typeof dt === 'string' && /T00:00(:00(\.0+)?)?$/.test(dt.replace(/[zZ]$|[+\-]\d{2}:\d{2}$/, ''));
+
+async function handleUpdateEvent(args) {
+  const { eventId, subject, start, end, attendees, body, location, isAllDay, showAs, recurrence } = args;
+
+  if (!eventId) {
+    return {
+      content: [{ type: "text", text: "eventId is required to update an event." }]
+    };
+  }
+
+  if (showAs !== undefined && !ALLOWED_SHOW_AS.includes(showAs)) {
+    return {
+      content: [{
+        type: "text",
+        text: `Invalid showAs value '${showAs}'. Must be one of: ${ALLOWED_SHOW_AS.join(', ')}.`
+      }]
+    };
+  }
+
+  if (recurrence !== undefined && recurrence !== null) {
+    const recurrenceCheck = validateRecurrence(recurrence);
+    if (!recurrenceCheck.ok) {
+      return { content: [{ type: "text", text: recurrenceCheck.error }] };
+    }
+  }
+
+  const patch = {};
+  if (subject !== undefined) patch.subject = subject;
+  if (body !== undefined) patch.body = { contentType: "HTML", content: body };
+  if (location !== undefined) patch.location = { displayName: location };
+  if (attendees !== undefined) {
+    patch.attendees = attendees.map(email => ({ emailAddress: { address: email }, type: "required" }));
+  }
+  if (start !== undefined) {
+    patch.start = { dateTime: start.dateTime || start, timeZone: start.timeZone || DEFAULT_TIMEZONE };
+  }
+  if (end !== undefined) {
+    patch.end = { dateTime: end.dateTime || end, timeZone: end.timeZone || DEFAULT_TIMEZONE };
+  }
+  if (isAllDay !== undefined) patch.isAllDay = isAllDay === true;
+  if (showAs !== undefined) patch.showAs = showAs;
+  if (recurrence !== undefined) patch.recurrence = recurrence; // pass null to clear the series
+
+  if (isAllDay === true) {
+    const startDt = patch.start?.dateTime;
+    const endDt = patch.end?.dateTime;
+    if ((startDt !== undefined && !isMidnight(startDt)) || (endDt !== undefined && !isMidnight(endDt))) {
+      return {
+        content: [{
+          type: "text",
+          text: "All-day events require start and end to be at midnight (e.g. '2026-04-14T00:00:00') in the supplied timeZone."
+        }]
+      };
+    }
+  }
+
+  if (Object.keys(patch).length === 0) {
+    return {
+      content: [{ type: "text", text: "No fields to update. Provide at least one updatable property." }]
+    };
+  }
+
+  try {
+    const accessToken = await ensureAuthenticated();
+    const endpoint = `me/events/${eventId}`;
+    await callGraphAPI(accessToken, 'PATCH', endpoint, patch);
+
+    return {
+      content: [{
+        type: "text",
+        text: `Event ${eventId} updated (${Object.keys(patch).join(', ')}).`
+      }]
+    };
+  } catch (error) {
+    if (error.message === 'Authentication required') {
+      return {
+        content: [{
+          type: "text",
+          text: "Authentication required. Please use the 'authenticate' tool first."
+        }]
+      };
+    }
+    return {
+      content: [{ type: "text", text: `Error updating event: ${error.message}` }]
+    };
+  }
+}
+
+module.exports = handleUpdateEvent;

--- a/config.js
+++ b/config.js
@@ -28,15 +28,12 @@ module.exports = {
   // Microsoft Graph API
   GRAPH_API_ENDPOINT: 'https://graph.microsoft.com/v1.0/',
   
-  // Calendar constants
-  CALENDAR_SELECT_FIELDS: 'id,subject,start,end,location,bodyPreview,isAllDay,recurrence,attendees',
-
   // Email constants
   EMAIL_SELECT_FIELDS: 'id,subject,from,toRecipients,ccRecipients,receivedDateTime,bodyPreview,hasAttachments,importance,isRead',
   EMAIL_DETAIL_FIELDS: 'id,subject,from,toRecipients,ccRecipients,bccRecipients,receivedDateTime,bodyPreview,body,hasAttachments,importance,isRead,internetMessageHeaders',
-  
+
   // Calendar constants
-  CALENDAR_SELECT_FIELDS: 'id,subject,bodyPreview,start,end,location,organizer,attendees,isAllDay,isCancelled',
+  CALENDAR_SELECT_FIELDS: 'id,subject,bodyPreview,start,end,location,organizer,attendees,isAllDay,isCancelled,showAs',
   
   // Pagination
   DEFAULT_PAGE_SIZE: 25,


### PR DESCRIPTION
# Changes:

- list-events now requests and renders showAs and isAllDay (adds [All day] tag and Status: line); removes a duplicate CALENDAR_SELECT_FIELDS key in config.js.
- create-event accepts optional isAllDay and showAs, with validation that all-day events start/end at midnight and that showAs is one of Graph's allowed values.
- New update-event tool PATCHes any subset of subject/start/end/location/ attendees/body/isAllDay/showAs/recurrence on an existing event.
- New shared recurrence validator + JSON schema (calendar/recurrence.js) wired into both create-event and update-event, mirroring Graph's patternedRecurrence shape. update-event accepts recurrence: null to clear a series.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ability to update existing calendar events
  * Full support for recurring events with validation
  * Enhanced all-day event handling with improved display formatting
  * Event status display in listings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->