### PR TITLE
Fix auth refresh, nested folder lookup, and Mail.ReadWrite scope

### DIFF
--- a/auth/tools.js
+++ b/auth/tools.js
@@ -55,25 +55,30 @@ async function handleAuthenticate(args) {
  */
 async function handleCheckAuthStatus() {
   console.error('[CHECK-AUTH-STATUS] Starting authentication status check');
-  
-  const tokens = tokenManager.loadTokenCache();
-  
-  console.error(`[CHECK-AUTH-STATUS] Tokens loaded: ${tokens ? 'YES' : 'NO'}`);
-  
-  if (!tokens || !tokens.access_token) {
-    console.error('[CHECK-AUTH-STATUS] No valid access token found');
+
+  // Use ensureAuthenticated so an expired access_token is refreshed via the
+  // refresh_token grant instead of being reported as "not authenticated".
+  // Lazy-require to avoid a circular dependency with auth/index.js.
+  const { ensureAuthenticated } = require('./index');
+
+  try {
+    const accessToken = await ensureAuthenticated();
+    if (!accessToken) {
+      console.error('[CHECK-AUTH-STATUS] ensureAuthenticated returned no token');
+      return {
+        content: [{ type: "text", text: "Not authenticated" }]
+      };
+    }
+    console.error('[CHECK-AUTH-STATUS] Authenticated (token valid or refreshed)');
+    return {
+      content: [{ type: "text", text: "Authenticated and ready" }]
+    };
+  } catch (error) {
+    console.error('[CHECK-AUTH-STATUS] Authentication check failed:', error.message);
     return {
       content: [{ type: "text", text: "Not authenticated" }]
     };
   }
-  
-  console.error('[CHECK-AUTH-STATUS] Access token present');
-  console.error(`[CHECK-AUTH-STATUS] Token expires at: ${tokens.expires_at}`);
-  console.error(`[CHECK-AUTH-STATUS] Current time: ${Date.now()}`);
-  
-  return {
-    content: [{ type: "text", text: "Authenticated and ready" }]
-  };
 }
 
 // Tool definitions

--- a/auth/tools.js
+++ b/auth/tools.js
@@ -66,7 +66,7 @@ async function handleCheckAuthStatus() {
     if (!accessToken) {
       console.error('[CHECK-AUTH-STATUS] ensureAuthenticated returned no token');
       return {
-        content: [{ type: "text", text: "Not authenticated" }]
+        content: [{ type: "text", text: "UNAUTHORIZED" }]
       };
     }
     console.error('[CHECK-AUTH-STATUS] Authenticated (token valid or refreshed)');
@@ -76,7 +76,7 @@ async function handleCheckAuthStatus() {
   } catch (error) {
     console.error('[CHECK-AUTH-STATUS] Authentication check failed:', error.message);
     return {
-      content: [{ type: "text", text: "Not authenticated" }]
+      content: [{ type: "text", text: "UNAUTHORIZED" }]
     };
   }
 }

--- a/email/folder-utils.js
+++ b/email/folder-utils.js
@@ -67,22 +67,30 @@ async function resolveFolderPath(accessToken, folderName) {
  */
 async function getFolderIdByName(accessToken, folderName) {
   try {
-    // First try with exact match filter
     console.error(`Looking for folder with name "${folderName}"`);
+
+    // Detect path-style input (e.g. "Archive/2024", "Inbox/To Delete") and
+    // walk it segment-by-segment instead of treating the whole string as one name.
+    const segments = folderName.split('/').map(s => s.trim()).filter(Boolean);
+    if (segments.length > 1) {
+      return await getFolderIdByPath(accessToken, segments);
+    }
+
+    // Single-segment: exact match filter first
     const response = await callGraphAPI(
       accessToken,
       'GET',
       'me/mailFolders',
       null,
-      { $filter: `displayName eq '${folderName}'` }
+      { $filter: `displayName eq '${folderName.replace(/'/g, "''")}'` }
     );
-    
+
     if (response.value && response.value.length > 0) {
       console.error(`Found folder "${folderName}" with ID: ${response.value[0].id}`);
       return response.value[0].id;
     }
-    
-    // If exact match fails, try to get all folders and do a case-insensitive comparison
+
+    // Case-insensitive fallback across top-level folders
     console.error(`No exact match found for "${folderName}", trying case-insensitive search`);
     const allFoldersResponse = await callGraphAPI(
       accessToken,
@@ -91,7 +99,7 @@ async function getFolderIdByName(accessToken, folderName) {
       null,
       { $top: 100, $select: 'id,displayName,childFolderCount' }
     );
-    
+
     if (allFoldersResponse.value) {
       const lowerFolderName = folderName.toLowerCase();
       const matchingFolder = allFoldersResponse.value.find(
@@ -103,28 +111,29 @@ async function getFolderIdByName(accessToken, folderName) {
         return matchingFolder.id;
       }
 
-      // Search child folders of any folder that has children
+      // Search one level of child folders in parallel
       const foldersWithChildren = allFoldersResponse.value.filter(f => f.childFolderCount > 0);
-      for (const parentFolder of foldersWithChildren) {
+      const childResults = await Promise.all(foldersWithChildren.map(async (parent) => {
         try {
-          const childResponse = await callGraphAPI(
+          const res = await callGraphAPI(
             accessToken,
             'GET',
-            `me/mailFolders/${parentFolder.id}/childFolders`,
+            `me/mailFolders/${parent.id}/childFolders`,
             null,
-            { $top: 100 }
+            { $top: 100, $select: 'id,displayName,childFolderCount' }
           );
-          if (childResponse.value) {
-            const childMatch = childResponse.value.find(
-              f => f.displayName.toLowerCase() === lowerFolderName
-            );
-            if (childMatch) {
-              console.error(`Found child folder "${folderName}" under "${parentFolder.displayName}" with ID: ${childMatch.id}`);
-              return childMatch.id;
-            }
-          }
+          return { parent, children: res.value || [] };
         } catch (err) {
-          console.error(`Error searching child folders of "${parentFolder.displayName}": ${err.message}`);
+          console.error(`Error searching child folders of "${parent.displayName}": ${err.message}`);
+          return { parent, children: [] };
+        }
+      }));
+
+      for (const { parent, children } of childResults) {
+        const match = children.find(f => f.displayName.toLowerCase() === lowerFolderName);
+        if (match) {
+          console.error(`Found child folder "${folderName}" under "${parent.displayName}" with ID: ${match.id}`);
+          return match.id;
         }
       }
     }
@@ -135,6 +144,63 @@ async function getFolderIdByName(accessToken, folderName) {
     console.error(`Error finding folder "${folderName}": ${error.message}`);
     return null;
   }
+}
+
+/**
+ * Walk a slash-separated folder path segment by segment.
+ * @param {string} accessToken
+ * @param {string[]} segments - path segments, e.g. ['Archive', '2024']
+ * @returns {Promise<string|null>} - Folder ID of the final segment or null
+ */
+async function getFolderIdByPath(accessToken, segments) {
+  console.error(`Resolving folder path: ${segments.join('/')}`);
+
+  // Find the root segment among top-level folders
+  const rootResponse = await callGraphAPI(
+    accessToken,
+    'GET',
+    'me/mailFolders',
+    null,
+    { $top: 100, $select: 'id,displayName,childFolderCount' }
+  );
+
+  if (!rootResponse.value) {
+    return null;
+  }
+
+  const rootName = segments[0].toLowerCase();
+  let current = rootResponse.value.find(f => f.displayName.toLowerCase() === rootName);
+  if (!current) {
+    console.error(`Root segment "${segments[0]}" not found among top-level folders`);
+    return null;
+  }
+
+  // Walk remaining segments
+  for (let i = 1; i < segments.length; i++) {
+    if (!current || current.childFolderCount === 0) {
+      console.error(`Segment "${segments[i - 1]}" has no children; cannot resolve "${segments[i]}"`);
+      return null;
+    }
+    const childResponse = await callGraphAPI(
+      accessToken,
+      'GET',
+      `me/mailFolders/${current.id}/childFolders`,
+      null,
+      { $top: 100, $select: 'id,displayName,childFolderCount' }
+    );
+    if (!childResponse.value) {
+      return null;
+    }
+    const next = segments[i].toLowerCase();
+    current = childResponse.value.find(f => f.displayName.toLowerCase() === next);
+    if (!current) {
+      console.error(`Segment "${segments[i]}" not found under "${segments[i - 1]}"`);
+      return null;
+    }
+  }
+
+  console.error(`Resolved path "${segments.join('/')}" to ID: ${current.id}`);
+  return current.id;
 }
 
 /**

--- a/email/folder-utils.js
+++ b/email/folder-utils.js
@@ -89,7 +89,7 @@ async function getFolderIdByName(accessToken, folderName) {
       'GET',
       'me/mailFolders',
       null,
-      { $top: 100 }
+      { $top: 100, $select: 'id,displayName,childFolderCount' }
     );
     
     if (allFoldersResponse.value) {
@@ -97,13 +97,38 @@ async function getFolderIdByName(accessToken, folderName) {
       const matchingFolder = allFoldersResponse.value.find(
         folder => folder.displayName.toLowerCase() === lowerFolderName
       );
-      
+
       if (matchingFolder) {
         console.error(`Found case-insensitive match for "${folderName}" with ID: ${matchingFolder.id}`);
         return matchingFolder.id;
       }
+
+      // Search child folders of any folder that has children
+      const foldersWithChildren = allFoldersResponse.value.filter(f => f.childFolderCount > 0);
+      for (const parentFolder of foldersWithChildren) {
+        try {
+          const childResponse = await callGraphAPI(
+            accessToken,
+            'GET',
+            `me/mailFolders/${parentFolder.id}/childFolders`,
+            null,
+            { $top: 100 }
+          );
+          if (childResponse.value) {
+            const childMatch = childResponse.value.find(
+              f => f.displayName.toLowerCase() === lowerFolderName
+            );
+            if (childMatch) {
+              console.error(`Found child folder "${folderName}" under "${parentFolder.displayName}" with ID: ${childMatch.id}`);
+              return childMatch.id;
+            }
+          }
+        } catch (err) {
+          console.error(`Error searching child folders of "${parentFolder.displayName}": ${err.message}`);
+        }
+      }
     }
-    
+
     console.error(`No folder found matching "${folderName}"`);
     return null;
   } catch (error) {

--- a/outlook-auth-server.js
+++ b/outlook-auth-server.js
@@ -47,6 +47,7 @@ const AUTH_CONFIG = {
     'offline_access',
     'User.Read',
     'Mail.Read',
+    'Mail.ReadWrite',
     'Mail.Send',
     'Calendars.Read',
     'Calendars.ReadWrite',


### PR DESCRIPTION
## Summary

Three independent fixes found running this MCP in production:

1. **check-auth-status now refreshes expired tokens.** Previously it used the sync `loadTokenCache` which returns null when `expires_at` is in the past, causing it to report `Not authenticated` while a valid `refresh_token` was sitting in the same file. Switched to `ensureAuthenticated()` (same code path the other tools already use).
2. **`getFolderIdByName` walks into subfolders.** `me/mailFolders` only returns top-level folders, so moving to common destinations like `To Delete` (under Inbox) or `Archive/2024` failed with `folder not found`. After the top-level miss, iterate folders with `childFolderCount > 0` and look up children.
3. **Auth server now requests `Mail.ReadWrite`.** `config.js` already lists it but `outlook-auth-server.js` didn't, so issued tokens couldn't move/delete drafts. Add the scope so users re-consent once and writes work.

Each fix is a separate commit for easier review.

## Test plan

- [x] Manual: `check-auth-status` after token expiry → returns `Authenticated and ready` (refresh fires).
- [x] Manual: `move-emails` to `To Delete` (subfolder of Inbox) → resolves correctly.
- [x] Manual: After re-auth with new scope, `move-emails` actually moves (no 403).
- [ ] Existing `npm test` suite continues to pass.

## Notes

Users will need to re-authenticate once after upgrading so the new `Mail.ReadWrite` scope is granted. Worth calling out in the release notes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication checks to better recover from expired tokens and provide clearer authenticated/unauthenticated responses.
  * Enhanced folder lookup to support slash-separated path names and more robust case-insensitive searches across folder hierarchies.

* **New Features**
  * Added Mail.ReadWrite permission to enable expanded mail operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryaker/outlook-mcp/pull/62?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->