### PR TITLE
ci: Dockerfile und GHCR-Publish-Workflow hinzufügen

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,37 @@
+node_modules
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Git / CI
+.git
+.github
+.gitignore
+
+# Environment & Secrets
+.env
+.env.*
+*.pem
+*.key
+*.cert
+*.token.json
+.outlook-mcp-tokens.json
+
+# Editor / OS
+.idea
+.vscode
+.DS_Store
+Thumbs.db
+*.swp
+*.swo
+
+# Claude Code
+.claude
+
+# Logs
+logs
+*.log
+
+# Docker
+Dockerfile
+.dockerignore

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,56 @@
+name: Build and Publish Docker Image
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=tag
+            type=sha
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+# syntax=docker/dockerfile:1
+
+FROM node:20-alpine AS deps
+WORKDIR /app
+
+# Nur Manifeste kopieren, damit der Layer-Cache bei reinen Code-Änderungen greift
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev
+
+FROM node:20-alpine AS runtime
+WORKDIR /app
+
+ENV NODE_ENV=production
+
+# Produktions-Abhängigkeiten aus dem deps-Stage übernehmen
+COPY --from=deps /app/node_modules ./node_modules
+
+# Anwendungscode kopieren (siehe .dockerignore für Ausschlüsse)
+COPY . .
+
+# Als non-root laufen (Image bringt den User "node" mit)
+USER node
+
+# MCP-Server kommuniziert über stdio
+ENTRYPOINT ["node", "index.js"]


### PR DESCRIPTION
## Ziel
Ein Docker-Image für den MCP-Server bereitstellen, das bei jedem Push automatisch in die GitHub Container Registry (GHCR) gepusht wird.

## Änderungen
- **`Dockerfile`** — Multi-Stage-Build auf `node:20-alpine`
  - `deps`-Stage: `npm ci --omit=dev` (Production-only, Layer-Cache-freundlich)
  - `runtime`-Stage: läuft als non-root-User `node`, `ENTRYPOINT ["node", "index.js"]` (stdio)
- **`.dockerignore`** — schließt Secrets/Tokens, `node_modules`, CI- und Editor-Dateien aus
- **`.github/workflows/docker-publish.yml`** — baut und published nach `ghcr.io/<owner>/<repo>`
  - Trigger: Push auf `main`, Tags `v*`, manuell (`workflow_dispatch`)
  - Login via automatischem `GITHUB_TOKEN` (kein zusätzliches Secret nötig)
  - Tags via `docker/metadata-action`: Branch, Git-Tag, SHA, `latest` auf Default-Branch
  - Multi-Arch (`linux/amd64`, `linux/arm64`) mit GHA-Build-Cache

## Verifikation
Lokal getestet:
- `docker build` läuft sauber durch
- Container startet und beantwortet `initialize` + `tools/list` korrekt über stdio (alle 35 Tools)

## Hinweis
Credentials (`OUTLOOK_CLIENT_ID`/`OUTLOOK_CLIENT_SECRET`) werden zur Laufzeit als Env-Variablen übergeben, nicht ins Image gebacken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Docker containerization with multi-stage build configuration
  * Enabled automated Docker image publishing to GitHub Container Registry on commits and version tags
  * Extended platform compatibility with multi-architecture support (Linux amd64, arm64)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->