### PR TITLE
Add Microsoft To Do MCP tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A comprehensive MCP (Model Context Protocol) server that connects Claude with Mi
 ## Supported Services
 
 - **Outlook** - Email, calendar, folders, and rules
+- **Microsoft To Do** - Task lists and tasks
 - **OneDrive** - Files, folders, search, and sharing
 - **Power Automate** - Flows, environments, and run history
 
@@ -52,6 +53,10 @@ A comprehensive MCP (Model Context Protocol) server that connects Claude with Mi
 │   ├── upload-large.js      # Chunked upload (>4MB)
 │   ├── share.js             # Create sharing link
 │   └── folder.js            # Create/delete folders
+├── todo/                    # Microsoft To Do functionality
+│   ├── index.js             # To Do exports
+│   ├── lists.js             # List task lists
+│   └── tasks.js             # List tasks in a task list
 ├── power-automate/          # Power Automate functionality
 │   ├── index.js             # Power Automate exports
 │   ├── flow-api.js          # Flow API client
@@ -71,6 +76,7 @@ A comprehensive MCP (Model Context Protocol) server that connects Claude with Mi
 - **Authentication**: OAuth 2.0 authentication with Microsoft Graph API (+ Flow API for Power Automate)
 - **Email Management**: List, search, read, send, and organize emails
 - **Calendar Management**: List, create, accept, decline, and delete calendar events
+- **Microsoft To Do**: List task lists and tasks
 - **OneDrive Integration**: List, search, upload, download, and share files
 - **Power Automate**: List environments/flows, trigger flows, view run history
 - **Modular Structure**: Clean separation of concerns for maintainability
@@ -96,6 +102,12 @@ A comprehensive MCP (Model Context Protocol) server that connects Claude with Mi
 | `move-emails` | Move emails between folders |
 | `list-rules` | List inbox rules |
 | `create-rule` | Create inbox rule |
+
+### Microsoft To Do
+| Tool | Description |
+|------|-------------|
+| `list-todo-lists` | List Microsoft To Do task lists |
+| `list-todo-tasks` | List tasks in a Microsoft To Do task list |
 
 ### OneDrive
 | Tool | Description |
@@ -163,6 +175,7 @@ npm install
    - `User.Read`
    - `Mail.Read`, `Mail.ReadWrite`, `Mail.Send`
    - `Calendars.Read`, `Calendars.ReadWrite`
+   - `Tasks.ReadWrite`
    - `Files.Read`, `Files.ReadWrite`
 4. Click "Add permissions"
 

--- a/auth/oauth-server.js
+++ b/auth/oauth-server.js
@@ -59,7 +59,7 @@ function createAuthConfig(envPrefix = 'MS_') {
     clientId: process.env[`${envPrefix}CLIENT_ID`] || '',
     clientSecret: process.env[`${envPrefix}CLIENT_SECRET`] || '',
     redirectUri: process.env[`${envPrefix}REDIRECT_URI`] || 'http://localhost:3333/auth/callback',
-    scopes: (process.env[`${envPrefix}SCOPES`] || 'offline_access User.Read Mail.Read').split(' '),
+    scopes: (process.env[`${envPrefix}SCOPES`] || 'offline_access User.Read Mail.Read Mail.Send Calendars.Read Calendars.ReadWrite Contacts.Read Tasks.ReadWrite').split(' '),
     tenantId,
     tokenEndpoint: process.env[`${envPrefix}TOKEN_ENDPOINT`] || `${authorityHost}/${tenantId}/oauth2/v2.0/token`,
     authEndpoint: process.env[`${envPrefix}AUTH_ENDPOINT`] || `${authorityHost}/${tenantId}/oauth2/v2.0/authorize`

--- a/auth/token-storage.js
+++ b/auth/token-storage.js
@@ -17,7 +17,7 @@ class TokenStorage {
       clientId,
       clientSecret,
       redirectUri: process.env.MS_REDIRECT_URI || 'http://localhost:3333/auth/callback',
-      scopes: (process.env.MS_SCOPES || 'offline_access User.Read Mail.Read').split(' '),
+      scopes: (process.env.MS_SCOPES || 'offline_access User.Read Mail.Read Mail.Send Calendars.Read Calendars.ReadWrite Contacts.Read Tasks.ReadWrite').split(' '),
       tenantId,
       tokenEndpoint: process.env.MS_TOKEN_ENDPOINT || `${authorityHost}/${tenantId}/oauth2/v2.0/token`,
       refreshTokenBuffer: 5 * 60 * 1000, // 5 minutes buffer for token refresh
@@ -36,11 +36,11 @@ class TokenStorage {
     try {
       const tokenData = await fs.readFile(this.config.tokenStorePath, 'utf8');
       this.tokens = JSON.parse(tokenData);
-      console.log('Tokens loaded from file.');
+      console.error('Tokens loaded from file.');
       return this.tokens;
     } catch (error) {
       if (error.code === 'ENOENT') {
-        console.log('Token file not found. No tokens loaded.');
+        console.error('Token file not found. No tokens loaded.');
       } else {
         console.error('Error loading token cache:', error);
       }
@@ -56,7 +56,7 @@ class TokenStorage {
     }
     try {
       await fs.writeFile(this.config.tokenStorePath, JSON.stringify(this.tokens, null, 2), { mode: 0o600 });
-      console.log('Tokens saved successfully.');
+      console.error('Tokens saved successfully.');
       // return true; // No longer returning boolean, will throw on error.
     } catch (error) {
       console.error('Error saving token cache:', error);
@@ -92,12 +92,12 @@ class TokenStorage {
     await this.getTokens(); // Ensure tokens are loaded
 
     if (!this.tokens || !this.tokens.access_token) {
-      console.log('No access token available.');
+      console.error('No access token available.');
       return null;
     }
 
     if (this.isTokenExpired()) {
-      console.log('Access token expired or nearing expiration. Attempting refresh.');
+      console.error('Access token expired or nearing expiration. Attempting refresh.');
       if (this.tokens.refresh_token) {
         try {
           return await this.refreshAccessToken();
@@ -124,11 +124,11 @@ class TokenStorage {
 
     // Prevent multiple concurrent refresh attempts
     if (this._refreshPromise) {
-        console.log("Refresh already in progress, returning existing promise.");
+        console.error("Refresh already in progress, returning existing promise.");
         return this._refreshPromise.then(tokens => tokens.access_token);
     }
 
-    console.log('Attempting to refresh access token...');
+    console.error('Attempting to refresh access token...');
     const postData = querystring.stringify({
       client_id: this.config.clientId,
       client_secret: this.config.clientSecret,
@@ -162,7 +162,7 @@ class TokenStorage {
                         this.tokens.expires_at = Date.now() + (responseBody.expires_in * 1000);
                         try {
                             await this._saveTokensToFile();
-                            console.log('Access token refreshed and saved successfully.');
+                            console.error('Access token refreshed and saved successfully.');
                             resolve(this.tokens);
                         } catch (saveError) {
                             console.error('Failed to save refreshed tokens:', saveError);
@@ -201,7 +201,7 @@ class TokenStorage {
     if (!this.config.clientId || !this.config.clientSecret) {
         throw new Error("Client ID or Client Secret is not configured. Cannot exchange code for tokens.");
     }
-    console.log('Exchanging authorization code for tokens...');
+    console.error('Exchanging authorization code for tokens...');
     const postData = querystring.stringify({
       client_id: this.config.clientId,
       client_secret: this.config.clientSecret,
@@ -237,7 +237,7 @@ class TokenStorage {
               };
               try {
                 await this._saveTokensToFile();
-                console.log('Tokens exchanged and saved successfully.');
+                console.error('Tokens exchanged and saved successfully.');
                 resolve(this.tokens);
               } catch (saveError) {
                 console.error('Failed to save exchanged tokens:', saveError);
@@ -269,10 +269,10 @@ class TokenStorage {
     this.tokens = null;
     try {
       await fs.unlink(this.config.tokenStorePath);
-      console.log('Token file deleted successfully.');
+      console.error('Token file deleted successfully.');
     } catch (error) {
       if (error.code === 'ENOENT') {
-        console.log('Token file not found, nothing to delete.');
+        console.error('Token file not found, nothing to delete.');
       } else {
         console.error('Error deleting token file:', error);
       }

--- a/auth/tools.js
+++ b/auth/tools.js
@@ -2,7 +2,9 @@
  * Authentication-related tools for the Outlook MCP server
  */
 const config = require('../config');
-const tokenManager = require('./token-manager');
+const TokenStorage = require('./token-storage');
+
+const tokenStorage = new TokenStorage();
 
 /**
  * About tool handler
@@ -12,7 +14,7 @@ async function handleAbout() {
   return {
     content: [{
       type: "text",
-      text: `M365 Assistant MCP Server v${config.SERVER_VERSION}\n\nProvides access to Microsoft 365 services through Microsoft Graph API:\n- Outlook (email, calendar, folders, rules)\n- OneDrive (files, folders, sharing)\n- Power Automate (flows, environments, runs)\n\nModular architecture for improved maintainability.`
+      text: `M365 Assistant MCP Server v${config.SERVER_VERSION}\n\nProvides access to Microsoft 365 services through Microsoft Graph API:\n- Outlook (email, calendar, folders, rules)\n- Microsoft To Do (task lists, tasks)\n- OneDrive (files, folders, sharing)\n- Power Automate (flows, environments, runs)\n\nModular architecture for improved maintainability.`
     }]
   };
 }
@@ -55,22 +57,30 @@ async function handleAuthenticate(args) {
  */
 async function handleCheckAuthStatus() {
   console.error('[CHECK-AUTH-STATUS] Starting authentication status check');
-  
-  const tokens = tokenManager.loadTokenCache();
-  
+
+  const tokens = await tokenStorage.getTokens();
+
   console.error(`[CHECK-AUTH-STATUS] Tokens loaded: ${tokens ? 'YES' : 'NO'}`);
-  
+
   if (!tokens || !tokens.access_token) {
     console.error('[CHECK-AUTH-STATUS] No valid access token found');
     return {
       content: [{ type: "text", text: "Not authenticated" }]
     };
   }
-  
+
   console.error('[CHECK-AUTH-STATUS] Access token present');
   console.error(`[CHECK-AUTH-STATUS] Token expires at: ${tokens.expires_at}`);
   console.error(`[CHECK-AUTH-STATUS] Current time: ${Date.now()}`);
-  
+
+  const accessToken = await tokenStorage.getValidAccessToken();
+  if (!accessToken) {
+    console.error('[CHECK-AUTH-STATUS] Could not obtain a valid access token');
+    return {
+      content: [{ type: "text", text: "Not authenticated" }]
+    };
+  }
+
   return {
     content: [{ type: "text", text: "Authenticated and ready" }]
   };

--- a/config.js
+++ b/config.js
@@ -20,7 +20,7 @@ module.exports = {
     clientId: process.env.OUTLOOK_CLIENT_ID || '',
     clientSecret: process.env.OUTLOOK_CLIENT_SECRET || '',
     redirectUri: 'http://localhost:3333/auth/callback',
-    scopes: ['Mail.Read', 'Mail.ReadWrite', 'Mail.Send', 'User.Read', 'Calendars.Read', 'Calendars.ReadWrite', 'Files.Read', 'Files.ReadWrite'],
+    scopes: ['Mail.Read', 'Mail.ReadWrite', 'Mail.Send', 'User.Read', 'Calendars.Read', 'Calendars.ReadWrite', 'Files.Read', 'Files.ReadWrite', 'Tasks.ReadWrite'],
     tokenStorePath: path.join(homeDir, '.outlook-mcp-tokens.json'),
     authServerUrl: 'http://localhost:3333'
   },
@@ -34,7 +34,11 @@ module.exports = {
   // Email constants
   EMAIL_SELECT_FIELDS: 'id,subject,from,toRecipients,ccRecipients,receivedDateTime,bodyPreview,hasAttachments,importance,isRead',
   EMAIL_DETAIL_FIELDS: 'id,subject,from,toRecipients,ccRecipients,bccRecipients,receivedDateTime,bodyPreview,body,hasAttachments,importance,isRead,internetMessageHeaders',
-  
+
+  // Microsoft To Do constants
+  TODO_LIST_SELECT_FIELDS: 'id,displayName,isOwner,wellknownListName',
+  TODO_TASK_SELECT_FIELDS: 'id,title,status,importance,body,dueDateTime,completedDateTime,createdDateTime,lastModifiedDateTime,isReminderOn',
+
   // Calendar constants
   CALENDAR_SELECT_FIELDS: 'id,subject,bodyPreview,start,end,location,organizer,attendees,isAllDay,isCancelled',
   

--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ const { emailTools } = require('./email');
 const { folderTools } = require('./folder');
 const { rulesTools } = require('./rules');
 const { onedriveTools } = require('./onedrive');
+const { todoTools } = require('./todo');
 const { powerAutomateTools } = require('./power-automate');
 
 // Log startup information
@@ -31,6 +32,7 @@ const TOOLS = [
   ...folderTools,
   ...rulesTools,
   ...onedriveTools,
+  ...todoTools,
   ...powerAutomateTools
 ];
 

--- a/outlook-auth-server.js
+++ b/outlook-auth-server.js
@@ -50,7 +50,8 @@ const AUTH_CONFIG = {
     'Mail.Send',
     'Calendars.Read',
     'Calendars.ReadWrite',
-    'Contacts.Read'
+    'Contacts.Read',
+    'Tasks.ReadWrite'
   ],
   tokenStorePath: path.join(process.env.HOME || process.env.USERPROFILE, '.outlook-mcp-tokens.json')
 };

--- a/test/auth/tools.test.js
+++ b/test/auth/tools.test.js
@@ -1,0 +1,78 @@
+describe('handleCheckAuthStatus', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  it('returns not authenticated when no token file is present', async () => {
+    const getTokens = jest.fn().mockResolvedValue(null);
+    const getValidAccessToken = jest.fn();
+
+    jest.doMock('../../auth/token-storage', () => {
+      return jest.fn().mockImplementation(() => ({
+        getTokens,
+        getValidAccessToken,
+      }));
+    });
+
+    const { handleCheckAuthStatus } = require('../../auth/tools');
+
+    const result = await handleCheckAuthStatus();
+
+    expect(result).toEqual({
+      content: [{ type: 'text', text: 'Not authenticated' }],
+    });
+    expect(getValidAccessToken).not.toHaveBeenCalled();
+  });
+
+  it('returns authenticated when a valid access token can be obtained', async () => {
+    const getTokens = jest.fn().mockResolvedValue({
+      access_token: 'cached-token',
+      expires_at: Date.now() + 60_000,
+    });
+    const getValidAccessToken = jest.fn().mockResolvedValue('fresh-token');
+
+    jest.doMock('../../auth/token-storage', () => {
+      return jest.fn().mockImplementation(() => ({
+        getTokens,
+        getValidAccessToken,
+      }));
+    });
+
+    const { handleCheckAuthStatus } = require('../../auth/tools');
+
+    const result = await handleCheckAuthStatus();
+
+    expect(getTokens).toHaveBeenCalledTimes(1);
+    expect(getValidAccessToken).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({
+      content: [{ type: 'text', text: 'Authenticated and ready' }],
+    });
+  });
+
+  it('returns authenticated when the cached token is expired but refresh succeeds', async () => {
+    const getTokens = jest.fn().mockResolvedValue({
+      access_token: 'expired-token',
+      expires_at: Date.now() - 60_000,
+      refresh_token: 'refresh-token',
+    });
+    const getValidAccessToken = jest.fn().mockResolvedValue('refreshed-token');
+
+    jest.doMock('../../auth/token-storage', () => {
+      return jest.fn().mockImplementation(() => ({
+        getTokens,
+        getValidAccessToken,
+      }));
+    });
+
+    const { handleCheckAuthStatus } = require('../../auth/tools');
+
+    const result = await handleCheckAuthStatus();
+
+    expect(getTokens).toHaveBeenCalledTimes(1);
+    expect(getValidAccessToken).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({
+      content: [{ type: 'text', text: 'Authenticated and ready' }],
+    });
+  });
+});

--- a/test/todo/handlers.test.js
+++ b/test/todo/handlers.test.js
@@ -1,0 +1,146 @@
+const handleListTodoLists = require('../../todo/lists');
+const handleListTodoTasks = require('../../todo/tasks');
+const { callGraphAPI } = require('../../utils/graph-api');
+const { ensureAuthenticated } = require('../../auth');
+
+jest.mock('../../utils/graph-api');
+jest.mock('../../auth');
+
+describe('Microsoft To Do handlers', () => {
+  const mockAccessToken = 'dummy_access_token';
+
+  beforeEach(() => {
+    callGraphAPI.mockClear();
+    ensureAuthenticated.mockClear();
+  });
+
+  describe('handleListTodoLists', () => {
+    test('lists available task lists', async () => {
+      ensureAuthenticated.mockResolvedValue(mockAccessToken);
+      callGraphAPI.mockResolvedValue({
+        value: [
+          {
+            id: 'list-1',
+            displayName: 'Tasks',
+            isOwner: true,
+            wellknownListName: 'defaultList'
+          },
+          {
+            id: 'list-2',
+            displayName: 'Work',
+            isOwner: true,
+            wellknownListName: 'none'
+          }
+        ]
+      });
+
+      const result = await handleListTodoLists({ count: 5 });
+
+      expect(ensureAuthenticated).toHaveBeenCalledTimes(1);
+      expect(callGraphAPI).toHaveBeenCalledWith(
+        mockAccessToken,
+        'GET',
+        'me/todo/lists',
+        null,
+        expect.objectContaining({ $top: 5 })
+      );
+      expect(result.content[0].text).toContain('Found 2 Microsoft To Do task lists');
+      expect(result.content[0].text).toContain('Tasks');
+      expect(result.content[0].text).toContain('ID: list-1');
+    });
+
+    test('returns a helpful empty-state message when no task lists exist', async () => {
+      ensureAuthenticated.mockResolvedValue(mockAccessToken);
+      callGraphAPI.mockResolvedValue({ value: [] });
+
+      const result = await handleListTodoLists({});
+
+      expect(result.content[0].text).toBe('No Microsoft To Do task lists found.');
+    });
+
+    test('returns an authentication prompt when auth is missing', async () => {
+      ensureAuthenticated.mockRejectedValue(new Error('Authentication required'));
+
+      const result = await handleListTodoLists({});
+
+      expect(result.content[0].text).toBe("Authentication required. Please use the 'authenticate' tool first.");
+      expect(callGraphAPI).not.toHaveBeenCalled();
+    });
+
+    test('surfaces missing To Do permissions clearly when Graph rejects the request', async () => {
+      ensureAuthenticated.mockResolvedValue(mockAccessToken);
+      callGraphAPI.mockRejectedValue(new Error('UNAUTHORIZED'));
+
+      const result = await handleListTodoLists({});
+
+      expect(result.content[0].text).toContain('Microsoft To Do access is not authorized for the current token');
+    });
+  });
+
+  describe('handleListTodoTasks', () => {
+    test('lists tasks from a task list by id', async () => {
+      ensureAuthenticated.mockResolvedValue(mockAccessToken);
+      callGraphAPI.mockResolvedValue({
+        value: [
+          {
+            id: 'task-1',
+            title: 'Pay rent',
+            status: 'notStarted',
+            importance: 'high',
+            dueDateTime: { dateTime: '2026-07-01T21:00:00.0000000', timeZone: 'UTC' },
+            body: { content: 'Before the first of the month' }
+          },
+          {
+            id: 'task-2',
+            title: 'Buy groceries',
+            status: 'completed',
+            importance: 'normal',
+            completedDateTime: { dateTime: '2026-06-27T18:00:00.0000000', timeZone: 'UTC' },
+            body: { content: '' }
+          }
+        ]
+      });
+
+      const result = await handleListTodoTasks({ listId: 'list-1', count: 10 });
+
+      expect(ensureAuthenticated).toHaveBeenCalledTimes(1);
+      expect(callGraphAPI).toHaveBeenCalledWith(
+        mockAccessToken,
+        'GET',
+        'me/todo/lists/list-1/tasks',
+        null,
+        expect.objectContaining({ $top: 10 })
+      );
+      expect(result.content[0].text).toContain('Found 2 tasks in Microsoft To Do list list-1');
+      expect(result.content[0].text).toContain('Pay rent');
+      expect(result.content[0].text).toContain('Status: completed');
+      expect(result.content[0].text).toContain('ID: task-2');
+    });
+
+    test('requires a task list id', async () => {
+      const result = await handleListTodoTasks({});
+
+      expect(result.content[0].text).toBe('A Microsoft To Do listId is required.');
+      expect(ensureAuthenticated).not.toHaveBeenCalled();
+      expect(callGraphAPI).not.toHaveBeenCalled();
+    });
+
+    test('returns a helpful empty-state message when a task list has no tasks', async () => {
+      ensureAuthenticated.mockResolvedValue(mockAccessToken);
+      callGraphAPI.mockResolvedValue({ value: [] });
+
+      const result = await handleListTodoTasks({ listId: 'list-empty' });
+
+      expect(result.content[0].text).toBe('No Microsoft To Do tasks found in list list-empty.');
+    });
+
+    test('returns an authentication prompt when auth is missing', async () => {
+      ensureAuthenticated.mockRejectedValue(new Error('Authentication required'));
+
+      const result = await handleListTodoTasks({ listId: 'list-1' });
+
+      expect(result.content[0].text).toBe("Authentication required. Please use the 'authenticate' tool first.");
+      expect(callGraphAPI).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/test/todo/handlers.test.js
+++ b/test/todo/handlers.test.js
@@ -42,11 +42,26 @@ describe('Microsoft To Do handlers', () => {
         'GET',
         'me/todo/lists',
         null,
-        expect.objectContaining({ $top: 5 })
+        { $top: 5 }
       );
       expect(result.content[0].text).toContain('Found 2 Microsoft To Do task lists');
       expect(result.content[0].text).toContain('Tasks');
       expect(result.content[0].text).toContain('ID: list-1');
+    });
+
+    test('does not send $select for todo lists because Graph rejects that query shape', async () => {
+      ensureAuthenticated.mockResolvedValue(mockAccessToken);
+      callGraphAPI.mockResolvedValue({ value: [] });
+
+      await handleListTodoLists({ count: 3 });
+
+      expect(callGraphAPI).toHaveBeenCalledWith(
+        mockAccessToken,
+        'GET',
+        'me/todo/lists',
+        null,
+        { $top: 3 }
+      );
     });
 
     test('returns a helpful empty-state message when no task lists exist', async () => {
@@ -109,12 +124,27 @@ describe('Microsoft To Do handlers', () => {
         'GET',
         'me/todo/lists/list-1/tasks',
         null,
-        expect.objectContaining({ $top: 10 })
+        { $top: 10 }
       );
       expect(result.content[0].text).toContain('Found 2 tasks in Microsoft To Do list list-1');
       expect(result.content[0].text).toContain('Pay rent');
       expect(result.content[0].text).toContain('Status: completed');
       expect(result.content[0].text).toContain('ID: task-2');
+    });
+
+    test('does not send $select for todo tasks because Graph rejects that query shape', async () => {
+      ensureAuthenticated.mockResolvedValue(mockAccessToken);
+      callGraphAPI.mockResolvedValue({ value: [] });
+
+      await handleListTodoTasks({ listId: 'list-1', count: 4 });
+
+      expect(callGraphAPI).toHaveBeenCalledWith(
+        mockAccessToken,
+        'GET',
+        'me/todo/lists/list-1/tasks',
+        null,
+        { $top: 4 }
+      );
     });
 
     test('requires a task list id', async () => {

--- a/todo/index.js
+++ b/todo/index.js
@@ -1,0 +1,48 @@
+/**
+ * Microsoft To Do module for Outlook MCP server
+ */
+const handleListTodoLists = require('./lists');
+const handleListTodoTasks = require('./tasks');
+
+const todoTools = [
+  {
+    name: 'list-todo-lists',
+    description: 'Lists Microsoft To Do task lists available to the signed-in account',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        count: {
+          type: 'number',
+          description: 'Number of task lists to retrieve (default: 10, max: 50)'
+        }
+      },
+      required: []
+    },
+    handler: handleListTodoLists,
+  },
+  {
+    name: 'list-todo-tasks',
+    description: 'Lists tasks in a Microsoft To Do task list',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        listId: {
+          type: 'string',
+          description: 'The Microsoft To Do task list ID to inspect'
+        },
+        count: {
+          type: 'number',
+          description: 'Number of tasks to retrieve (default: 10, max: 50)'
+        }
+      },
+      required: ['listId']
+    },
+    handler: handleListTodoTasks,
+  }
+];
+
+module.exports = {
+  todoTools,
+  handleListTodoLists,
+  handleListTodoTasks,
+};

--- a/todo/lists.js
+++ b/todo/lists.js
@@ -1,0 +1,69 @@
+/**
+ * List Microsoft To Do task lists functionality
+ */
+const config = require('../config');
+const { callGraphAPI } = require('../utils/graph-api');
+const { ensureAuthenticated } = require('../auth');
+
+async function handleListTodoLists(args = {}) {
+  const count = Math.min(args.count || 10, config.MAX_RESULT_COUNT);
+
+  try {
+    const accessToken = await ensureAuthenticated();
+    const response = await callGraphAPI(
+      accessToken,
+      'GET',
+      'me/todo/lists',
+      null,
+      {
+        $top: count,
+        $select: config.TODO_LIST_SELECT_FIELDS,
+      }
+    );
+
+    if (!response.value || response.value.length === 0) {
+      return {
+        content: [{ type: 'text', text: 'No Microsoft To Do task lists found.' }]
+      };
+    }
+
+    const listText = response.value.map((list, index) => {
+      const wellKnown = list.wellknownListName && list.wellknownListName !== 'none'
+        ? `\nWell-known list: ${list.wellknownListName}`
+        : '';
+      const ownerStatus = typeof list.isOwner === 'boolean'
+        ? `\nOwner: ${list.isOwner ? 'yes' : 'no'}`
+        : '';
+
+      return `${index + 1}. ${list.displayName || 'Untitled list'}${ownerStatus}${wellKnown}\nID: ${list.id}\n`;
+    }).join('\n');
+
+    return {
+      content: [{
+        type: 'text',
+        text: `Found ${response.value.length} Microsoft To Do task lists:\n\n${listText}`
+      }]
+    };
+  } catch (error) {
+    if (error.message === 'Authentication required') {
+      return {
+        content: [{ type: 'text', text: "Authentication required. Please use the 'authenticate' tool first." }]
+      };
+    }
+
+    if (error.message === 'UNAUTHORIZED') {
+      return {
+        content: [{
+          type: 'text',
+          text: 'Microsoft To Do access is not authorized for the current token. Re-authenticate after granting Tasks.ReadWrite.'
+        }]
+      };
+    }
+
+    return {
+      content: [{ type: 'text', text: `Error listing Microsoft To Do task lists: ${error.message}` }]
+    };
+  }
+}
+
+module.exports = handleListTodoLists;

--- a/todo/lists.js
+++ b/todo/lists.js
@@ -17,7 +17,6 @@ async function handleListTodoLists(args = {}) {
       null,
       {
         $top: count,
-        $select: config.TODO_LIST_SELECT_FIELDS,
       }
     );
 

--- a/todo/tasks.js
+++ b/todo/tasks.js
@@ -1,0 +1,92 @@
+/**
+ * List Microsoft To Do tasks functionality
+ */
+const config = require('../config');
+const { callGraphAPI } = require('../utils/graph-api');
+const { ensureAuthenticated } = require('../auth');
+
+function formatGraphDateTime(dateTimeValue) {
+  if (!dateTimeValue || !dateTimeValue.dateTime) {
+    return 'None';
+  }
+
+  const raw = dateTimeValue.dateTime;
+  const zone = dateTimeValue.timeZone;
+  const hasOffset = /[zZ]$|[+\-]\d{2}:\d{2}$/.test(raw);
+  const iso = hasOffset ? raw : `${raw}Z`;
+  const parsed = new Date(iso);
+
+  if (!Number.isNaN(parsed.getTime())) {
+    return parsed.toLocaleString();
+  }
+
+  return zone ? `${raw} (${zone})` : raw;
+}
+
+async function handleListTodoTasks(args = {}) {
+  const listId = args.listId;
+  if (!listId) {
+    return {
+      content: [{ type: 'text', text: 'A Microsoft To Do listId is required.' }]
+    };
+  }
+
+  const count = Math.min(args.count || 10, config.MAX_RESULT_COUNT);
+
+  try {
+    const accessToken = await ensureAuthenticated();
+    const response = await callGraphAPI(
+      accessToken,
+      'GET',
+      `me/todo/lists/${listId}/tasks`,
+      null,
+      {
+        $top: count,
+        $select: config.TODO_TASK_SELECT_FIELDS,
+      }
+    );
+
+    if (!response.value || response.value.length === 0) {
+      return {
+        content: [{ type: 'text', text: `No Microsoft To Do tasks found in list ${listId}.` }]
+      };
+    }
+
+    const taskText = response.value.map((task, index) => {
+      const due = formatGraphDateTime(task.dueDateTime);
+      const completed = formatGraphDateTime(task.completedDateTime);
+      const importance = task.importance || 'normal';
+      const body = task.body?.content ? `\nNotes: ${task.body.content}` : '';
+
+      return `${index + 1}. ${task.title || 'Untitled task'}\nStatus: ${task.status || 'unknown'}\nImportance: ${importance}\nDue: ${due}\nCompleted: ${completed}${body}\nID: ${task.id}\n`;
+    }).join('\n');
+
+    return {
+      content: [{
+        type: 'text',
+        text: `Found ${response.value.length} tasks in Microsoft To Do list ${listId}:\n\n${taskText}`
+      }]
+    };
+  } catch (error) {
+    if (error.message === 'Authentication required') {
+      return {
+        content: [{ type: 'text', text: "Authentication required. Please use the 'authenticate' tool first." }]
+      };
+    }
+
+    if (error.message === 'UNAUTHORIZED') {
+      return {
+        content: [{
+          type: 'text',
+          text: 'Microsoft To Do access is not authorized for the current token. Re-authenticate after granting Tasks.ReadWrite.'
+        }]
+      };
+    }
+
+    return {
+      content: [{ type: 'text', text: `Error listing Microsoft To Do tasks: ${error.message}` }]
+    };
+  }
+}
+
+module.exports = handleListTodoTasks;

--- a/todo/tasks.js
+++ b/todo/tasks.js
@@ -42,7 +42,6 @@ async function handleListTodoTasks(args = {}) {
       null,
       {
         $top: count,
-        $select: config.TODO_TASK_SELECT_FIELDS,
       }
     );
 

--- a/utils/mock-data.js
+++ b/utils/mock-data.js
@@ -129,6 +129,27 @@ function simulateGraphAPIResponse(method, path, data, queryParams) {
           { id: "deleteditems", displayName: "Deleted Items" }
         ]
       };
+    } else if (path === 'me/todo/lists') {
+      return {
+        value: [
+          { id: 'todo-default', displayName: 'Tasks', isOwner: true, wellknownListName: 'defaultList' },
+          { id: 'todo-work', displayName: 'Work', isOwner: true, wellknownListName: 'none' }
+        ]
+      };
+    } else if (/^me\/todo\/lists\/[^/]+\/tasks$/.test(path)) {
+      return {
+        value: [
+          {
+            id: 'todo-task-1',
+            title: 'Simulated To Do task',
+            status: 'notStarted',
+            importance: 'normal',
+            dueDateTime: { dateTime: new Date(Date.now() + 86400000).toISOString(), timeZone: 'UTC' },
+            completedDateTime: null,
+            body: { content: 'Created from mock test mode data.' }
+          }
+        ]
+      };
     }
   } else if (method === 'POST' && path.includes('sendMail')) {
     // Simulate a successful email send


### PR DESCRIPTION
## Summary
- add Microsoft To Do MCP tools for listing task lists and tasks
- request `Tasks.ReadWrite` in auth defaults and document the new permission
- add Jest coverage for To Do handlers and auth status token checks

## Testing
- npm test -- --runTestsByPath test/todo/handlers.test.js test/auth/tools.test.js
- node index.js MCP initialize + tools/list transport verification

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Microsoft To Do support, including tools to list task lists and list tasks for a selected list.
  * Extended Microsoft Graph app access to include To Do permissions so To Do data can be retrieved.
* **Bug Fixes**
  * Improved authentication readiness checks to more reliably confirm a usable access token before reporting the app as ready.
  * Updated authentication-related server messaging for clearer “unauthorized/missing auth” guidance.
* **Documentation**
  * Updated the README with Microsoft To Do setup details, required permissions, and the new available tools.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->