### PR TITLE
test: update TokenStorage warning expectation to match new message

### DIFF
--- a/test/auth/token-storage.test.js
+++ b/test/auth/token-storage.test.js
@@ -47,7 +47,7 @@ describe('TokenStorage', () => {
     it('should warn if client ID or secret is missing', () => {
       const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
       new TokenStorage({ ...baseConfig, clientId: null });
-      expect(consoleWarnSpy).toHaveBeenCalledWith("TokenStorage: MS_CLIENT_ID or MS_CLIENT_SECRET is not configured. Token operations might fail.");
+      expect(consoleWarnSpy).toHaveBeenCalledWith("TokenStorage: Client ID or Secret is not configured (checked MS_CLIENT_ID/OUTLOOK_CLIENT_ID). Token refresh will fail.");
       consoleWarnSpy.mockRestore();
     });
   });


### PR DESCRIPTION
## Summary
PR #48 changed the missing-credentials warning in `auth/token-storage.js` to:

> TokenStorage: Client ID or Secret is not configured (checked MS_CLIENT_ID/OUTLOOK_CLIENT_ID). Token refresh will fail.

but the test "TokenStorage › Constructor › should warn if client ID or secret is missing" in `test/auth/token-storage.test.js` still expected the old wording, so it failed. This updates the test expectation to match the current message.

## Testing
- `npm test` — all 131 tests pass (7 suites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the warning shown when required Outlook/Microsoft client credentials are missing, with clearer wording about token refresh failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->