### PR TITLE
fix(auth): refresh expired token in check-auth-status instead of reporting "Not authenticated"

### DIFF
--- a/auth/tools.js
+++ b/auth/tools.js
@@ -2,7 +2,10 @@
  * Authentication-related tools for the Outlook MCP server
  */
 const config = require('../config');
-const tokenManager = require('./token-manager');
+const TokenStorage = require('./token-storage');
+
+// Singleton with automatic refresh — same path used by the actual API calls
+const tokenStorage = new TokenStorage();
 
 /**
  * About tool handler
@@ -55,22 +58,26 @@ async function handleAuthenticate(args) {
  */
 async function handleCheckAuthStatus() {
   console.error('[CHECK-AUTH-STATUS] Starting authentication status check');
-  
-  const tokens = tokenManager.loadTokenCache();
-  
-  console.error(`[CHECK-AUTH-STATUS] Tokens loaded: ${tokens ? 'YES' : 'NO'}`);
-  
-  if (!tokens || !tokens.access_token) {
-    console.error('[CHECK-AUTH-STATUS] No valid access token found');
+
+  // Use getValidAccessToken: if the access token expired but a valid
+  // refresh_token exists, it refreshes silently instead of reporting
+  // "Not authenticated".
+  let accessToken = null;
+  try {
+    accessToken = await tokenStorage.getValidAccessToken();
+  } catch (error) {
+    console.error('[CHECK-AUTH-STATUS] Error while validating/refreshing token:', error.message);
+  }
+
+  if (!accessToken) {
+    console.error('[CHECK-AUTH-STATUS] No valid access token (and refresh unavailable/failed)');
     return {
       content: [{ type: "text", text: "Not authenticated" }]
     };
   }
-  
-  console.error('[CHECK-AUTH-STATUS] Access token present');
-  console.error(`[CHECK-AUTH-STATUS] Token expires at: ${tokens.expires_at}`);
-  console.error(`[CHECK-AUTH-STATUS] Current time: ${Date.now()}`);
-  
+
+  console.error('[CHECK-AUTH-STATUS] Valid access token available (refreshed if needed)');
+
   return {
     content: [{ type: "text", text: "Authenticated and ready" }]
   };


### PR DESCRIPTION
## Problem

`check-auth-status` uses `tokenManager.loadTokenCache()`, which only inspects the **access token** and returns `null` once it expires (~1h) — reporting **"Not authenticated"** even when a valid `refresh_token` is present on disk.

On machines that aren't always on (a laptop/desktop that sleeps or shuts down), the access token expires while the machine is idle/off. The next `check-auth-status` then falsely reports a lost session and prompts a full browser re-login, even though the `refresh_token` grant would have renewed it silently.

Notably, the **actual Graph API calls don't have this problem** — they go through `ensureAuthenticated()` → `tokenStorage.getValidAccessToken()` (`auth/index.js`), which refreshes via the refresh token. Only the status check used the non-refreshing path.

## Fix

Switch `handleCheckAuthStatus` to `tokenStorage.getValidAccessToken()` — the same path already used by the real API calls — so an expired access token is refreshed via the `refresh_token` before reporting status. A `try/catch` reports "Not authenticated" cleanly if the refresh genuinely fails (e.g. revoked/expired refresh token). Also drops the now-unused `token-manager` import from this file.

## Verification

Tested end-to-end against Microsoft with a personal (`consumers`) account: with the stored `expires_at` forced into the past (simulating a machine that was off for more than an hour), `getValidAccessToken()` refreshed the session via the refresh token with no browser round-trip, and `check-auth-status` then reports "Authenticated and ready".

Scope: single file, `auth/tools.js` (+20 / −13). No changes to the refresh logic itself or any other module.

---
Co-authored with Claude Opus.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication status checks so users are correctly marked as not authenticated when no valid session token is available.
  * Made token availability handling more reliable, reducing false-positive sign-in states and allowing silent refresh when possible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->