### PR TITLE
fix: use console.error for token diagnostics to keep stdio stdout clean

### DIFF
--- a/auth/token-manager.js
+++ b/auth/token-manager.js
@@ -123,7 +123,7 @@ function saveFlowTokens(flowTokens) {
     };
 
     fs.writeFileSync(tokenPath, JSON.stringify(mergedTokens, null, 2), { mode: 0o600 });
-    console.log('Flow tokens saved successfully');
+    console.error('Flow tokens saved successfully');
 
     // Update cache
     cachedTokens = mergedTokens;

--- a/auth/token-storage.js
+++ b/auth/token-storage.js
@@ -36,11 +36,11 @@ class TokenStorage {
     try {
       const tokenData = await fs.readFile(this.config.tokenStorePath, 'utf8');
       this.tokens = JSON.parse(tokenData);
-      console.log('Tokens loaded from file.');
+      console.error('Tokens loaded from file.');
       return this.tokens;
     } catch (error) {
       if (error.code === 'ENOENT') {
-        console.log('Token file not found. No tokens loaded.');
+        console.error('Token file not found. No tokens loaded.');
       } else {
         console.error('Error loading token cache:', error);
       }
@@ -56,7 +56,7 @@ class TokenStorage {
     }
     try {
       await fs.writeFile(this.config.tokenStorePath, JSON.stringify(this.tokens, null, 2), { mode: 0o600 });
-      console.log('Tokens saved successfully.');
+      console.error('Tokens saved successfully.');
       // return true; // No longer returning boolean, will throw on error.
     } catch (error) {
       console.error('Error saving token cache:', error);
@@ -92,12 +92,12 @@ class TokenStorage {
     await this.getTokens(); // Ensure tokens are loaded
 
     if (!this.tokens || !this.tokens.access_token) {
-      console.log('No access token available.');
+      console.error('No access token available.');
       return null;
     }
 
     if (this.isTokenExpired()) {
-      console.log('Access token expired or nearing expiration. Attempting refresh.');
+      console.error('Access token expired or nearing expiration. Attempting refresh.');
       if (this.tokens.refresh_token) {
         try {
           return await this.refreshAccessToken();
@@ -124,11 +124,11 @@ class TokenStorage {
 
     // Prevent multiple concurrent refresh attempts
     if (this._refreshPromise) {
-        console.log("Refresh already in progress, returning existing promise.");
+        console.error("Refresh already in progress, returning existing promise.");
         return this._refreshPromise.then(tokens => tokens.access_token);
     }
 
-    console.log('Attempting to refresh access token...');
+    console.error('Attempting to refresh access token...');
     const postData = querystring.stringify({
       client_id: this.config.clientId,
       client_secret: this.config.clientSecret,
@@ -162,7 +162,7 @@ class TokenStorage {
                         this.tokens.expires_at = Date.now() + (responseBody.expires_in * 1000);
                         try {
                             await this._saveTokensToFile();
-                            console.log('Access token refreshed and saved successfully.');
+                            console.error('Access token refreshed and saved successfully.');
                             resolve(this.tokens);
                         } catch (saveError) {
                             console.error('Failed to save refreshed tokens:', saveError);
@@ -201,7 +201,7 @@ class TokenStorage {
     if (!this.config.clientId || !this.config.clientSecret) {
         throw new Error("Client ID or Client Secret is not configured. Cannot exchange code for tokens.");
     }
-    console.log('Exchanging authorization code for tokens...');
+    console.error('Exchanging authorization code for tokens...');
     const postData = querystring.stringify({
       client_id: this.config.clientId,
       client_secret: this.config.clientSecret,
@@ -237,7 +237,7 @@ class TokenStorage {
               };
               try {
                 await this._saveTokensToFile();
-                console.log('Tokens exchanged and saved successfully.');
+                console.error('Tokens exchanged and saved successfully.');
                 resolve(this.tokens);
               } catch (saveError) {
                 console.error('Failed to save exchanged tokens:', saveError);
@@ -269,10 +269,10 @@ class TokenStorage {
     this.tokens = null;
     try {
       await fs.unlink(this.config.tokenStorePath);
-      console.log('Token file deleted successfully.');
+      console.error('Token file deleted successfully.');
     } catch (error) {
       if (error.code === 'ENOENT') {
-        console.log('Token file not found, nothing to delete.');
+        console.error('Token file not found, nothing to delete.');
       } else {
         console.error('Error deleting token file:', error);
       }

--- a/test/auth/token-storage.test.js
+++ b/test/auth/token-storage.test.js
@@ -47,7 +47,7 @@ describe('TokenStorage', () => {
     it('should warn if client ID or secret is missing', () => {
       const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
       new TokenStorage({ ...baseConfig, clientId: null });
-      expect(consoleWarnSpy).toHaveBeenCalledWith("TokenStorage: MS_CLIENT_ID or MS_CLIENT_SECRET is not configured. Token operations might fail.");
+      expect(consoleWarnSpy).toHaveBeenCalledWith("TokenStorage: Client ID or Secret is not configured (checked MS_CLIENT_ID/OUTLOOK_CLIENT_ID). Token refresh will fail.");
       consoleWarnSpy.mockRestore();
     });
   });
@@ -63,13 +63,13 @@ describe('TokenStorage', () => {
     });
 
     it('should return null and log if file does not exist (ENOENT)', async () => {
-      const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation();
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
       fs.readFile.mockRejectedValue({ code: 'ENOENT' });
       const loaded = await tokenStorage._loadTokensFromFile();
       expect(loaded).toBeNull();
       expect(tokenStorage.tokens).toBeNull();
-      expect(consoleLogSpy).toHaveBeenCalledWith('Token file not found. No tokens loaded.');
-      consoleLogSpy.mockRestore();
+      expect(consoleErrorSpy).toHaveBeenCalledWith('Token file not found. No tokens loaded.');
+      consoleErrorSpy.mockRestore();
     });
 
     it('should return null and log error for other read errors', async () => {
@@ -541,12 +541,12 @@ describe('TokenStorage', () => {
 
     it('should log if token file does not exist during unlink', async () => {
       fs.unlink.mockRejectedValue({ code: 'ENOENT' });
-      const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation();
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
 
       await tokenStorage.clearTokens();
 
-      expect(consoleLogSpy).toHaveBeenCalledWith('Token file not found, nothing to delete.');
-      consoleLogSpy.mockRestore();
+      expect(consoleErrorSpy).toHaveBeenCalledWith('Token file not found, nothing to delete.');
+      consoleErrorSpy.mockRestore();
     });
 
     it('should log error for other unlink errors', async () => {
@@ -556,6 +556,26 @@ describe('TokenStorage', () => {
       await tokenStorage.clearTokens();
 
       expect(consoleErrorSpy).toHaveBeenCalledWith('Error deleting token file:', expect.any(Error));
+      consoleErrorSpy.mockRestore();
+    });
+  });
+
+  describe('stdout protocol safety', () => {
+    // Regression guard: under the MCP stdio transport, stdout is the JSON-RPC
+    // channel, so diagnostics must go to stderr (console.error), never stdout
+    // (console.log). The token save path previously used console.log
+    // ("Tokens saved successfully."), which corrupted the protocol stream and
+    // dropped the server from Claude Desktop.
+    it('should route the save diagnostic to stderr, not stdout', async () => {
+      const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation();
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+      tokenStorage.tokens = { access_token: 'save_token' };
+
+      await tokenStorage._saveTokensToFile();
+
+      expect(consoleLogSpy).not.toHaveBeenCalled();
+      expect(consoleErrorSpy).toHaveBeenCalledWith('Tokens saved successfully.');
+      consoleLogSpy.mockRestore();
       consoleErrorSpy.mockRestore();
     });
   });

--- a/test/auth/token-storage.test.js
+++ b/test/auth/token-storage.test.js
@@ -571,12 +571,15 @@ describe('TokenStorage', () => {
       const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
       tokenStorage.tokens = { access_token: 'save_token' };
 
-      await tokenStorage._saveTokensToFile();
+      try {
+        await tokenStorage._saveTokensToFile();
 
-      expect(consoleLogSpy).not.toHaveBeenCalled();
-      expect(consoleErrorSpy).toHaveBeenCalledWith('Tokens saved successfully.');
-      consoleLogSpy.mockRestore();
-      consoleErrorSpy.mockRestore();
+        expect(consoleLogSpy).not.toHaveBeenCalled();
+        expect(consoleErrorSpy).toHaveBeenCalledWith('Tokens saved successfully.');
+      } finally {
+        consoleLogSpy.mockRestore();
+        consoleErrorSpy.mockRestore();
+      }
     });
   });
 });


### PR DESCRIPTION
## Problem
Token load/save/refresh logging in `auth/token-storage.js` and
`auth/token-manager.js` used `console.log`, which writes to stdout. Under the
MCP stdio transport, stdout is the JSON-RPC channel, so these lines corrupted
the stream during a token refresh triggered by a tool call. Claude Desktop threw:

    Unexpected token 'A', "Access tok"... is not valid JSON

and dropped the server from Connectors. Startup looked fine; the failure only
surfaced once an auth-touching tool call ran.

## Fix
Redirected all 13 `console.log` calls in the two token files to `console.error`
(stderr). Logs are unchanged; they just no longer pollute the protocol stream.

## Tests
- Updated two `console.log` spy assertions in `token-storage.test.js` to match.
- Added a regression guard asserting token diagnostics go to stderr, not stdout.
- Corrected one pre-existing stale assertion in the same file (unrelated to this
  fix, but the file wouldn't otherwise pass).
- Full suite green: `npm test` → 132 passed.
- Verified live under `@modelcontextprotocol/inspector`: `create-event` runs the
  auth path with no stdout JSON-RPC corruption.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved protocol reliability by routing token-management status, success, and warning diagnostics from standard output to the error stream.
  * Updated token load/save/refresh and clearing scenarios to emit messages with consistent severity, without changing token behavior.

* **Tests**
  * Adjusted assertions to expect stderr diagnostics instead of stdout across token storage paths.
  * Added a regression check ensuring token save success writes to the error stream and never uses standard output for JSON/protocol safety.
  * Updated related credential and token-file message expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->