### PR TITLE
fix(auth): honour MS_SCOPES in the OAuth consent request

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,11 +192,16 @@ MS_CLIENT_ID=your-application-client-id-here
 MS_CLIENT_SECRET=your-client-secret-VALUE-here
 MS_TENANT_ID=your-tenant-id-here
 USE_TEST_MODE=false
+
+# Optional: override the requested OAuth scopes (space separated)
+MS_SCOPES=offline_access User.Read Mail.ReadWrite Mail.Send Calendars.ReadWrite
 ```
 
 **Important Notes:**
 - Use `MS_CLIENT_ID` and `MS_CLIENT_SECRET` in the `.env` file
 - Set `MS_TENANT_ID` for single-tenant apps to avoid `/common` endpoint errors
+- `MS_SCOPES` is optional; when set it is used both for the consent request and for
+  token refresh. Leave it unset to keep the default scope list.
 - For Claude Desktop config, you'll use `OUTLOOK_CLIENT_ID` and `OUTLOOK_CLIENT_SECRET`
 - Always use the client secret **VALUE**, never the Secret ID
 

--- a/outlook-auth-server.js
+++ b/outlook-auth-server.js
@@ -43,7 +43,9 @@ const AUTH_CONFIG = {
   tenantId: process.env.MS_TENANT_ID || 'common',
   authorityHost: (process.env.MS_AUTHORITY_HOST || 'https://login.microsoftonline.com').replace(/\/+$/, ''),
   redirectUri: 'http://localhost:3333/auth/callback',
-  scopes: [
+  // MS_SCOPES honours the same env var token-storage.js uses for refresh, so the
+  // consented scopes and the refreshed scopes can't drift apart.
+  scopes: (process.env.MS_SCOPES || [
     'offline_access',
     'User.Read',
     'Mail.Read',
@@ -51,7 +53,7 @@ const AUTH_CONFIG = {
     'Calendars.Read',
     'Calendars.ReadWrite',
     'Contacts.Read'
-  ],
+  ].join(' ')).split(' ').filter(Boolean),
   tokenStorePath: path.join(process.env.HOME || process.env.USERPROFILE, '.outlook-mcp-tokens.json')
 };
 


### PR DESCRIPTION
## Problem

`outlook-auth-server.js` hardcodes its scope list, while `auth/token-storage.js` reads `MS_SCOPES` when refreshing tokens. The two disagree, and the consent request always wins — so setting `MS_SCOPES` has **no effect on what the user actually consents to**.

The practical failure: an Azure app registration with `Mail.ReadWrite` configured still produces a token whose granted scope is `Mail.Read` only. Every write tool then fails, without any obvious cause:

- `delete-email`
- `move-emails`
- `draft-email`
- `mark-as-read`

Reproduced on a personal Microsoft account (`MS_TENANT_ID=consumers`), commit `95d6ff2`:

```
# .env
MS_SCOPES=offline_access User.Read Mail.ReadWrite Mail.Send Calendars.ReadWrite

# granted token scope after npm run auth-server + consent
User.Read Mail.Read Mail.Send Calendars.Read Calendars.ReadWrite Contacts.Read
                ^^^^^^^^^ requested ReadWrite, got Read
                                                    ^^^^^^^^^^^^ never requested
```

Note the second half of the bug: `Contacts.Read` is consented even though nothing asks for it, because it is in the hardcoded list. Users grant more access than the app needs and less than it uses.

## Fix

Read `MS_SCOPES` in `AUTH_CONFIG`, keeping the existing list as the fallback, so consent and refresh can no longer drift apart. Behaviour is unchanged when `MS_SCOPES` is unset.

Also documents `MS_SCOPES` in the README env section, where it was previously undocumented.

## Verification

After the fix, with the same `.env`:

```
scope: User.Read Mail.ReadWrite Mail.Send Calendars.ReadWrite Calendars.Read Mail.Read Contacts.Read
```

End-to-end over stdio against a real mailbox:

| Tool | Before | After |
|---|---|---|
| `list-emails` | ✅ | ✅ |
| `draft-email` | ❌ insufficient privileges | ✅ draft created |
| `delete-email` | ❌ insufficient privileges | ✅ moved to Deleted Items |

(The test draft was deleted as part of the run.)

## Credit

Found and fixed while reviewing this server for a Microsoft 365 integration on [Jerico](https://jerico.appnova.io/?utm_source=github&utm_medium=pr&utm_campaign=outlook-mcp) — the security review flagged that the consent scopes and the refresh scopes were reading from different sources, which turned out to be a real functional bug rather than a hardening nit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring OAuth scopes with the optional `MS_SCOPES` environment variable.
  * Configured scopes are now applied consistently during authorization and token refresh.

* **Documentation**
  * Updated configuration guidance and important notes to explain `MS_SCOPES` usage and defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->