### PR TITLE
fix: bind auth server to loopback by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,9 @@ USE_TEST_MODE=false
 - Set `MS_TENANT_ID` for single-tenant apps to avoid `/common` endpoint errors
 - For Claude Desktop config, you'll use `OUTLOOK_CLIENT_ID` and `OUTLOOK_CLIENT_SECRET`
 - Always use the client secret **VALUE**, never the Secret ID
+- `MS_AUTH_SERVER_HOST` (optional) sets the interface the auth server binds to.
+  It defaults to `127.0.0.1`; set it to `0.0.0.0` only when running in a
+  container, as that exposes the OAuth callback to your whole network
 
 ### 2. Claude Desktop Configuration
 

--- a/outlook-auth-server.js
+++ b/outlook-auth-server.js
@@ -328,8 +328,12 @@ function exchangeCodeForTokens(code) {
 
 // Start server
 const PORT = 3333;
-server.listen(PORT, () => {
-  console.log(`Authentication server running at http://localhost:${PORT}`);
+// Bind to loopback by default: the OAuth redirect is delivered by a browser
+// on this same machine, so the server never needs to be reachable from the
+// network. Override (e.g. '0.0.0.0') only when running inside a container.
+const HOST = process.env.MS_AUTH_SERVER_HOST || '127.0.0.1';
+server.listen(PORT, HOST, () => {
+  console.log(`Authentication server running at http://${HOST}:${PORT}`);
   console.log(`Waiting for authentication callback at ${AUTH_CONFIG.redirectUri}`);
   console.log(`Token will be stored at: ${AUTH_CONFIG.tokenStorePath}`);
   


### PR DESCRIPTION
## Problem

`outlook-auth-server.js` calls `server.listen(PORT)` without a host argument, so Node binds the OAuth callback server to every interface rather than to loopback:

```
$ lsof -nP -iTCP:3333 -sTCP:LISTEN
node    1850 user   12u  IPv6  ...  TCP *:3333 (LISTEN)
```

On a shared network — an office LAN, a coworking space, a hotel Wi-Fi — that leaves `/auth/callback` reachable from every other host on the subnet. I found this on my own machine with a routine port scan from a colleague; ports 3333 and 11434 were open to the whole office. The callback handler writes to the token store, so it is worth closing even with the CSRF `state` check in place.

## Why loopback is enough

The project already assumes localhost everywhere:

- `config.js:22` — `redirectUri: 'http://localhost:3333/auth/callback'`
- `README.md` setup step 6 — Redirect URI: Web → `http://localhost:3333/auth/callback`
- `test/auth/oauth-server.test.js:197` — asserts the redirect URI is `http://localhost:3333/auth/callback`

The OAuth redirect is delivered by a browser running on the same machine as the server, so the listener never needs to accept connections from the network. The wide binding looks like an oversight rather than a deliberate choice.

## Change

- Default the bind address to `127.0.0.1`
- Add `MS_AUTH_SERVER_HOST`, following the existing `MS_` env convention, so anyone running this in a container can still set `0.0.0.0`
- Document the variable in the README, with a note on what setting it means

No behaviour change for the documented local setup. `node --check` passes; no existing test covers `outlook-auth-server.js`, and the `oauth-server` tests assert on `auth/oauth-server.js`, which this does not touch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring the authentication server’s bind address with `MS_AUTH_SERVER_HOST`.
  * The server defaults to `127.0.0.1` and supports container-friendly configurations such as `0.0.0.0`.
  * Startup messages now display the configured host and port.

* **Documentation**
  * Documented the new environment variable, default address, and container configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->